### PR TITLE
feature: http node client

### DIFF
--- a/src/NodeClient.ts
+++ b/src/NodeClient.ts
@@ -1,0 +1,86 @@
+import * as https from 'https'
+
+interface NodeClientRequest {
+  body: string | null,
+  options: {
+    hostname: string,
+    path: string,
+    method: string,
+    headers: Record<string, string>,
+  }
+}
+
+export class NodeClient {
+  public static async get (
+    host: string,
+    path: string,
+    headers: Record<string, string> = {}
+  ): Promise<Response> {
+    return await this.makeRequest(this.request(host, path, 'GET', headers, null))
+  }
+
+  public static async post (
+    host: string,
+    path: string,
+    headers: Record<string, string> = {},
+    body: Record<string, string>
+  ): Promise<Response> {
+    return await this.makeRequest(this.request(host, path, 'POST', headers, body))
+  }
+
+  public static async patch (
+    host: string,
+    path: string,
+    headers: Record<string, string> = {},
+    body: Record<string, string>
+  ): Promise<Response> {
+    return await this.makeRequest(this.request(host, path, 'PATCH', headers, body))
+  }
+
+  public static async put (
+    host: string,
+    path: string,
+    headers: Record<string, string> = {},
+    body: Record<string, string>
+  ): Promise<Response> {
+    return await this.makeRequest(this.request(host, path, 'PUT', headers, body))
+  }
+
+  public static async delete (
+    host: string,
+    path: string,
+    headers: Record<string, string> = {}
+  ): Promise<Response> {
+    return await this.makeRequest(this.request(host, path, 'DELETE', headers, null))
+  }
+
+  private static async makeRequest (request: NodeClientRequest): Promise<Response> {
+    return new Promise((resolve: Function, reject: Function) => {
+      const httpsRequest = https.request(request.options, (response) => {
+        let responseData: string = ''
+
+        response.on('data', (chunk) => responseData += chunk)
+
+        response.on('end', () =>
+          resolve(new Response(responseData, { status: response.statusCode, statusText: response.statusMessage }))
+        )
+      })
+
+      httpsRequest.on('error', (error) => { reject(error) })
+
+      if (request.body) httpsRequest.write(request.body)
+
+      httpsRequest.end()
+    })
+  }
+
+  private static request(
+    host: string,
+    path: string,
+    method: string,
+    headers: Record<string, string>,
+    body: Record<string, string> | null
+  ): NodeClientRequest {
+    return { body: JSON.stringify(body), options: { hostname: host, path, method, headers, body } } as NodeClientRequest
+  }
+}

--- a/src/NodeClient.ts
+++ b/src/NodeClient.ts
@@ -81,6 +81,6 @@ export class NodeClient {
     headers: Record<string, string>,
     body: Record<string, string> | null
   ): NodeClientRequest {
-    return { body: JSON.stringify(body), options: { hostname: host, path, method, headers, body } } as NodeClientRequest
+    return { body: JSON.stringify(body), options: { hostname: host, path, method, headers } } as NodeClientRequest
   }
 }

--- a/test/NodeClient.test.ts
+++ b/test/NodeClient.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+// @ts-nocheck
+import https from 'https'
+import { NodeClient } from '../src/NodeClient'
+import { setupHttpRecording } from './helpers/pollyHelpers'
+
+describe('NodeClient', () => {
+  // Enables Polly.js to record and replay HTTP requests for each test
+  setupHttpRecording()
+
+  describe ('.get', () => {
+    it ('performs GET request', async () => {
+      const response = await NodeClient.get('jsonplaceholder.typicode.com', '/todos/1')
+
+      expect(response.ok).toBeTruthy()
+    })
+  })
+
+  describe ('.post', () => {
+    it ('performs POST request', async () => {
+      const body = {
+        title: 'foo',
+        body: 'bar',
+        userId: 1,
+      }
+
+      const response = await NodeClient.post(
+        'jsonplaceholder.typicode.com',
+        '/posts',
+        {},
+        body
+      )
+
+      expect(response.status).toBe(201)
+    })
+  })
+
+  describe ('.patch', () => {
+    it ('performs PATCH request', async () => {
+      const body = { title: 'foo' }
+
+      const response = await NodeClient.patch(
+        'jsonplaceholder.typicode.com',
+        '/posts/1',
+        {},
+        body
+      )
+
+      expect(response.status).toBe(200)
+    })
+  })
+
+  describe ('.put', () => {
+    it ('performs PUT request', async () => {
+      const body = {
+        id: 1,
+        title: 'foo',
+        body: 'bar',
+        userId: 1
+      }
+
+      const response = await NodeClient.put(
+        'jsonplaceholder.typicode.com',
+        '/posts/1',
+        {},
+        body
+      )
+
+      expect(response.status).toBe(200)
+    })
+  })
+
+  describe ('.delete', () => {
+    it('performs DELETE request', async () => {
+      const response = await NodeClient.delete(
+        'jsonplaceholder.typicode.com',
+        '/todos/1'
+      )
+
+      expect(response.ok).toBeTruthy()
+    })
+  })
+})

--- a/test/NodeClient.test.ts
+++ b/test/NodeClient.test.ts
@@ -2,9 +2,10 @@
  * @jest-environment node
  */
 // @ts-nocheck
-import https from 'https'
+import * as https from 'https'
 import { NodeClient } from '../src/NodeClient'
 import { setupHttpRecording } from './helpers/pollyHelpers'
+import { assertRequestPayload, mockHttpsRequest, restoreHttpsRequest } from './helpers/httpsHelpers'
 
 describe('NodeClient', () => {
   // Enables Polly.js to record and replay HTTP requests for each test
@@ -15,6 +16,23 @@ describe('NodeClient', () => {
       const response = await NodeClient.get('jsonplaceholder.typicode.com', '/todos/1')
 
       expect(response.ok).toBeTruthy()
+    })
+
+    it ('performs request with given request payload', () => {
+      const options = {
+        hostname: 'jsonplaceholder.typicode.com',
+        path: 'todos/1',
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      }
+
+      const mock = mockHttpsRequest(options.hostname, options.path, options.method, options.headers)
+
+      NodeClient.get(options.hostname, options.path, options.headers)
+
+      assertRequestPayload(mock)
+
+      restoreHttpsRequest()
     })
   })
 
@@ -35,6 +53,29 @@ describe('NodeClient', () => {
 
       expect(response.status).toBe(201)
     })
+
+    it ('performs request with given request payload', () => {
+      const body = {
+        title: 'foo',
+        body: 'bar',
+        userId: 1,
+      }
+
+      const options = {
+        hostname: 'jsonplaceholder.typicode.com',
+        path: 'posts',
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' }
+      }
+
+      const mock = mockHttpsRequest(options.hostname, options.path, options.method, options.headers)
+
+      NodeClient.post(options.hostname, options.path, options.headers)
+
+      assertRequestPayload(mock)
+
+      restoreHttpsRequest()
+    })
   })
 
   describe ('.patch', () => {
@@ -49,6 +90,25 @@ describe('NodeClient', () => {
       )
 
       expect(response.status).toBe(200)
+    })
+
+    it ('performs request with given request payload', () => {
+      const body = { title: 'foo' }
+
+      const options = {
+        hostname: 'jsonplaceholder.typicode.com',
+        path: 'posts/1',
+        method: 'PATCH',
+        headers: { Authorization: 'Bearer token' }
+      }
+
+      const mock = mockHttpsRequest(options.hostname, options.path, options.method, options.headers)
+
+      NodeClient.patch(options.hostname, options.path, options.headers)
+
+      assertRequestPayload(mock)
+
+      restoreHttpsRequest()
     })
   })
 
@@ -70,6 +130,30 @@ describe('NodeClient', () => {
 
       expect(response.status).toBe(200)
     })
+
+    it ('performs request with given request payload', () => {
+      const body = {
+        id: 1,
+        title: 'foo',
+        body: 'bar',
+        userId: 1
+      }
+
+      const options = {
+        hostname: 'jsonplaceholder.typicode.com',
+        path: 'posts/1',
+        method: 'PUT',
+        headers: { Authorization: 'Bearer token' }
+      }
+
+      const mock = mockHttpsRequest(options.hostname, options.path, options.method, options.headers)
+
+      NodeClient.put(options.hostname, options.path, options.headers)
+
+      assertRequestPayload(mock)
+
+      restoreHttpsRequest()
+    })
   })
 
   describe ('.delete', () => {
@@ -80,6 +164,23 @@ describe('NodeClient', () => {
       )
 
       expect(response.ok).toBeTruthy()
+    })
+
+    it ('performs request with given request payload', () => {
+      const options = {
+        hostname: 'jsonplaceholder.typicode.com',
+        path: 'todos/1',
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer token' }
+      }
+
+      const mock = mockHttpsRequest(options.hostname, options.path, options.method, options.headers)
+
+      NodeClient.delete(options.hostname, options.path, options.headers)
+
+      assertRequestPayload(mock)
+
+      restoreHttpsRequest()
     })
   })
 })

--- a/test/helpers/httpsHelpers.ts
+++ b/test/helpers/httpsHelpers.ts
@@ -1,0 +1,14 @@
+export function mockFetch (): jest.Mock {
+  const mockFetch = jest.fn().mockResolvedValue(new Response())
+  jest.spyOn(globalThis, 'fetch').mockImplementation(mockFetch)
+  return mockFetch
+}
+
+export function restoreFetch (): void {
+  if (jest.isMockFunction(globalThis.fetch)) {
+    // @ts-ignore
+    globalThis.fetch.mockRestore()
+  } else {
+    throw('You tried to restore fetch, but it was not a mock function.')
+  }
+}

--- a/test/helpers/httpsHelpers.ts
+++ b/test/helpers/httpsHelpers.ts
@@ -1,14 +1,51 @@
-export function mockFetch (): jest.Mock {
-  const mockFetch = jest.fn().mockResolvedValue(new Response())
-  jest.spyOn(globalThis, 'fetch').mockImplementation(mockFetch)
-  return mockFetch
+import * as https from 'https'
+
+export function mockHttpsRequest (
+  host: string,
+  path: string,
+  method: string,
+  headers: string,
+  body: Record<string, string> | null = null
+): any {
+  const options = { hostname: host, path, method, headers }
+
+  const mockHttpsRequest = jest
+    .spyOn(https, 'request')
+    // @ts-ignore
+    .mockImplementation((opts, callback) => {
+      expect(opts).toEqual(options)
+
+      const mockResponse = {
+        statusCode: 200, headers: {},
+        on: jest.fn().mockImplementation((event, eventCallback) => {
+          if (event === 'data') {
+            eventCallback(JSON.stringify({ data: 'mock data' }))
+          }
+          if (event === 'end') {
+            eventCallback()
+          }
+        })
+      }
+
+      // @ts-ignore
+      callback(mockResponse)
+
+      return mockResponse
+    })
+
+  return mockHttpsRequest
 }
 
-export function restoreFetch (): void {
-  if (jest.isMockFunction(globalThis.fetch)) {
+export function restoreHttpsRequest (): void {
+  // @ts-ignore
+  if (jest.isMockFunction(https.request)) {
     // @ts-ignore
-    globalThis.fetch.mockRestore()
+    https.request.mockRestore()
   } else {
     throw('You tried to restore fetch, but it was not a mock function.')
   }
+}
+
+export function assertRequestPayload (mock: jest.Mock): void {
+  expect(mock).toHaveBeenCalled()
 }

--- a/test/helpers/pollyHelpers.ts
+++ b/test/helpers/pollyHelpers.ts
@@ -14,7 +14,7 @@ export function startHttpRecording() {
     { persisterOptions: { fs: { recordingsDir: recordName } } }
   )
 
-  return new Polly('#makeRequest', configuration)
+  return new Polly('recordings', configuration)
 }
 
 export async function stopHttpRecording(polly: Polly) {

--- a/test/records/FetchClient .delete performs DELETE request/recordings_613089741/recording.har
+++ b/test/records/FetchClient .delete performs DELETE request/recordings_613089741/recording.har
@@ -1,6 +1,6 @@
 {
   "log": {
-    "_recordingName": "#makeRequest",
+    "_recordingName": "recordings",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "83cdb6e8a95c44bcd4725b068961511d",
+        "_id": "5504f745b0e70b6f9a6da6ce1186363b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -25,7 +25,7 @@
             },
             {
               "name": "access-control-request-method",
-              "value": "PUT"
+              "value": "DELETE"
             },
             {
               "name": "user-agent",
@@ -36,11 +36,11 @@
               "value": "jsonplaceholder.typicode.com"
             }
           ],
-          "headersSize": 277,
+          "headersSize": 280,
           "httpVersion": "HTTP/1.1",
           "method": "OPTIONS",
           "queryString": [],
-          "url": "https://jsonplaceholder.typicode.com/posts/1"
+          "url": "https://jsonplaceholder.typicode.com/todos/1"
         },
         "response": {
           "bodySize": 0,
@@ -52,7 +52,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Sat, 24 Feb 2024 08:13:21 GMT"
+              "value": "Sun, 25 Feb 2024 09:57:25 GMT"
             },
             {
               "name": "content-length",
@@ -64,11 +64,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708762401&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=hvd%2Bww74tkEBMhZS1pb5GVsBf1yqalKqanE4qMCcmm4%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708855045&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=706k0NhVLgdc3wixnZigUqj9oMOPDXlzApjrbLa0a3M%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708762401&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=hvd%2Bww74tkEBMhZS1pb5GVsBf1yqalKqanE4qMCcmm4%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708855045&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=706k0NhVLgdc3wixnZigUqj9oMOPDXlzApjrbLa0a3M%3D"
             },
             {
               "name": "nel",
@@ -84,11 +84,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "996"
+              "value": "994"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1708762412"
+              "value": "1708855066"
             },
             {
               "name": "access-control-allow-origin",
@@ -120,21 +120,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85a63fae98722fc3-MAD"
+              "value": "85af158449532f8b-MAD"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1011,
+          "headersSize": 1007,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 204,
           "statusText": "No Content"
         },
-        "startedDateTime": "2024-02-24T08:13:19.629Z",
-        "time": 1438,
+        "startedDateTime": "2024-02-25T09:57:25.742Z",
+        "time": 144,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -142,21 +142,17 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1438
+          "wait": 144
         }
       },
       {
-        "_id": "449b8fa427f25f284537287a54949c90",
+        "_id": "36a64d11aa6304b6ecdce38b582db802",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 15,
+          "bodySize": 0,
           "cookies": [],
           "headers": [
-            {
-              "name": "content-type",
-              "value": "text/plain;charset=UTF-8"
-            },
             {
               "name": "referer",
               "value": "http://localhost/"
@@ -178,10 +174,6 @@
               "value": "http://localhost"
             },
             {
-              "name": "content-length",
-              "value": 15
-            },
-            {
               "name": "accept-encoding",
               "value": "gzip, deflate"
             },
@@ -190,29 +182,24 @@
               "value": "jsonplaceholder.typicode.com"
             }
           ],
-          "headersSize": 363,
+          "headersSize": 306,
           "httpVersion": "HTTP/1.1",
-          "method": "PUT",
-          "postData": {
-            "mimeType": "text/plain;charset=UTF-8",
-            "params": [],
-            "text": "[object Object]"
-          },
+          "method": "DELETE",
           "queryString": [],
-          "url": "https://jsonplaceholder.typicode.com/posts/1"
+          "url": "https://jsonplaceholder.typicode.com/todos/1"
         },
         "response": {
-          "bodySize": 13,
+          "bodySize": 2,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 13,
-            "text": "{\n  \"id\": 1\n}"
+            "size": 2,
+            "text": "{}"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Sat, 24 Feb 2024 08:13:21 GMT"
+              "value": "Sun, 25 Feb 2024 09:57:26 GMT"
             },
             {
               "name": "content-type",
@@ -220,7 +207,7 @@
             },
             {
               "name": "content-length",
-              "value": "13"
+              "value": "2"
             },
             {
               "name": "connection",
@@ -228,11 +215,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708762401&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=hvd%2Bww74tkEBMhZS1pb5GVsBf1yqalKqanE4qMCcmm4%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708855045&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=706k0NhVLgdc3wixnZigUqj9oMOPDXlzApjrbLa0a3M%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708762401&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=hvd%2Bww74tkEBMhZS1pb5GVsBf1yqalKqanE4qMCcmm4%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708855045&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=706k0NhVLgdc3wixnZigUqj9oMOPDXlzApjrbLa0a3M%3D"
             },
             {
               "name": "nel",
@@ -248,11 +235,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "995"
+              "value": "993"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1708762412"
+              "value": "1708855066"
             },
             {
               "name": "access-control-allow-origin",
@@ -284,7 +271,7 @@
             },
             {
               "name": "etag",
-              "value": "W/\"d-p13Thq1mbIznE8TsFv4BmW8SRpg\""
+              "value": "W/\"2-vyGp6PvFo4RvsFtPoIWeCReyIC8\""
             },
             {
               "name": "via",
@@ -300,21 +287,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85a63faf594e2fc3-MAD"
+              "value": "85af1584fa7c2f8b-MAD"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1112,
+          "headersSize": 1107,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-24T08:13:21.072Z",
-        "time": 330,
+        "startedDateTime": "2024-02-25T09:57:25.890Z",
+        "time": 110,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -322,7 +309,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 330
+          "wait": 110
         }
       }
     ],

--- a/test/records/FetchClient .get performs GET request/recordings_613089741/recording.har
+++ b/test/records/FetchClient .get performs GET request/recordings_613089741/recording.har
@@ -1,6 +1,6 @@
 {
   "log": {
-    "_recordingName": "#makeRequest",
+    "_recordingName": "recordings",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
@@ -8,17 +8,13 @@
     },
     "entries": [
       {
-        "_id": "7103348f0a98b9cf5f2961f29371dc38",
+        "_id": "76ae98e64be2b0371c8c4afb83c94963",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 15,
+          "bodySize": 0,
           "cookies": [],
           "headers": [
-            {
-              "name": "content-type",
-              "value": "text/plain;charset=UTF-8"
-            },
             {
               "name": "referer",
               "value": "http://localhost/"
@@ -40,10 +36,6 @@
               "value": "http://localhost"
             },
             {
-              "name": "content-length",
-              "value": 15
-            },
-            {
               "name": "accept-encoding",
               "value": "gzip, deflate"
             },
@@ -52,37 +44,33 @@
               "value": "jsonplaceholder.typicode.com"
             }
           ],
-          "headersSize": 362,
+          "headersSize": 303,
           "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "text/plain;charset=UTF-8",
-            "params": [],
-            "text": "[object Object]"
-          },
+          "method": "GET",
           "queryString": [],
-          "url": "https://jsonplaceholder.typicode.com/posts"
+          "url": "https://jsonplaceholder.typicode.com/todos/1"
         },
         "response": {
-          "bodySize": 15,
+          "bodySize": 120,
           "content": {
+            "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 15,
-            "text": "{\n  \"id\": 101\n}"
+            "size": 120,
+            "text": "[\"H4sIAAAAAAAAA6vmUlBQKi1OLfJMUbJSMNQBcTMRzJLMkpxUJSsFpZTUnNTkktJihcTSEhBOzVUCK0jOzy3ISS1JBWlJS8wpTuWqBQA33AG3UwAAAA==\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Sat, 24 Feb 2024 08:12:46 GMT"
+              "value": "Sun, 25 Feb 2024 09:57:22 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
             {
-              "name": "content-length",
-              "value": "15"
+              "name": "transfer-encoding",
+              "value": "chunked"
             },
             {
               "name": "connection",
@@ -90,11 +78,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708762366&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=xZOoiVFt1ngQuszoE%2FVNL2cvAUFQfIOmlEocKR4qH30%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708010098&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=zzGHRHAdMUJMVtLP7JMCAR%2B5Z8KaWpwagFNI7WGgMDA%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708762366&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=xZOoiVFt1ngQuszoE%2FVNL2cvAUFQfIOmlEocKR4qH30%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708010098&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=zzGHRHAdMUJMVtLP7JMCAR%2B5Z8KaWpwagFNI7WGgMDA%3D"
             },
             {
               "name": "nel",
@@ -114,7 +102,7 @@
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1708762412"
+              "value": "1708010137"
             },
             {
               "name": "access-control-allow-origin",
@@ -122,7 +110,7 @@
             },
             {
               "name": "vary",
-              "value": "Origin, X-HTTP-Method-Override, Accept-Encoding"
+              "value": "Origin, Accept-Encoding"
             },
             {
               "name": "access-control-allow-credentials",
@@ -130,7 +118,7 @@
             },
             {
               "name": "cache-control",
-              "value": "no-cache"
+              "value": "max-age=43200"
             },
             {
               "name": "pragma",
@@ -141,20 +129,12 @@
               "value": "-1"
             },
             {
-              "name": "access-control-expose-headers",
-              "value": "Location"
-            },
-            {
-              "name": "location",
-              "value": "https://jsonplaceholder.typicode.com/posts/101"
-            },
-            {
               "name": "x-content-type-options",
               "value": "nosniff"
             },
             {
               "name": "etag",
-              "value": "W/\"f-4jjw4Y8q22Yv1PV9m28FczJgjzk\""
+              "value": "W/\"53-hfEnumeNh6YirfjyjaujcOPPT+s\""
             },
             {
               "name": "via",
@@ -162,7 +142,11 @@
             },
             {
               "name": "cf-cache-status",
-              "value": "DYNAMIC"
+              "value": "HIT"
+            },
+            {
+              "name": "age",
+              "value": "23942"
             },
             {
               "name": "server",
@@ -170,21 +154,25 @@
             },
             {
               "name": "cf-ray",
-              "value": "85a63ed3b8dc2165-MAD"
+              "value": "85af157219b7218c-MAD"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1235,
+          "headersSize": 1158,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "https://jsonplaceholder.typicode.com/posts/101",
-          "status": 201,
-          "statusText": "Created"
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
         },
-        "startedDateTime": "2024-02-24T08:12:45.877Z",
-        "time": 162,
+        "startedDateTime": "2024-02-25T09:57:22.801Z",
+        "time": 99,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +180,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 162
+          "wait": 99
         }
       }
     ],

--- a/test/records/FetchClient .patch performs PATCH request/recordings_613089741/recording.har
+++ b/test/records/FetchClient .patch performs PATCH request/recordings_613089741/recording.har
@@ -1,6 +1,6 @@
 {
   "log": {
-    "_recordingName": "#makeRequest",
+    "_recordingName": "recordings",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "5504f745b0e70b6f9a6da6ce1186363b",
+        "_id": "3b67edba340ffbcc6e8ed5ddcf3fe94d",
         "_order": 0,
         "cache": {},
         "request": {
@@ -25,7 +25,7 @@
             },
             {
               "name": "access-control-request-method",
-              "value": "DELETE"
+              "value": "PATCH"
             },
             {
               "name": "user-agent",
@@ -36,11 +36,11 @@
               "value": "jsonplaceholder.typicode.com"
             }
           ],
-          "headersSize": 280,
+          "headersSize": 279,
           "httpVersion": "HTTP/1.1",
           "method": "OPTIONS",
           "queryString": [],
-          "url": "https://jsonplaceholder.typicode.com/todos/1"
+          "url": "https://jsonplaceholder.typicode.com/posts/1"
         },
         "response": {
           "bodySize": 0,
@@ -52,7 +52,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Sat, 24 Feb 2024 08:14:18 GMT"
+              "value": "Sun, 25 Feb 2024 09:57:23 GMT"
             },
             {
               "name": "content-length",
@@ -64,11 +64,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708762458&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=4s7zsw0x4QfpghXk5ikNJv3pQIBVAnD%2BzYCbQaJZTfY%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708855043&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=hL7Pvxu4%2FwVfvJ5Nmm%2FxvrPcqxu9CgZ8xkFtVOVyOGc%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708762458&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=4s7zsw0x4QfpghXk5ikNJv3pQIBVAnD%2BzYCbQaJZTfY%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708855043&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=hL7Pvxu4%2FwVfvJ5Nmm%2FxvrPcqxu9CgZ8xkFtVOVyOGc%3D"
             },
             {
               "name": "nel",
@@ -84,11 +84,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "999"
+              "value": "998"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1708762472"
+              "value": "1708855066"
             },
             {
               "name": "access-control-allow-origin",
@@ -120,21 +120,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85a64114fdf8214a-MAD"
+              "value": "85af1573ef5069ea-MAD"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1011,
+          "headersSize": 1015,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 204,
           "statusText": "No Content"
         },
-        "startedDateTime": "2024-02-24T08:14:14.149Z",
-        "time": 4514,
+        "startedDateTime": "2024-02-25T09:57:23.094Z",
+        "time": 171,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -142,17 +142,21 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 4514
+          "wait": 171
         }
       },
       {
-        "_id": "36a64d11aa6304b6ecdce38b582db802",
+        "_id": "131009a3a9feea658907944892945ed2",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 0,
+          "bodySize": 15,
           "cookies": [],
           "headers": [
+            {
+              "name": "content-type",
+              "value": "text/plain;charset=UTF-8"
+            },
             {
               "name": "referer",
               "value": "http://localhost/"
@@ -174,6 +178,10 @@
               "value": "http://localhost"
             },
             {
+              "name": "content-length",
+              "value": 15
+            },
+            {
               "name": "accept-encoding",
               "value": "gzip, deflate"
             },
@@ -182,32 +190,38 @@
               "value": "jsonplaceholder.typicode.com"
             }
           ],
-          "headersSize": 306,
+          "headersSize": 365,
           "httpVersion": "HTTP/1.1",
-          "method": "DELETE",
+          "method": "PATCH",
+          "postData": {
+            "mimeType": "text/plain;charset=UTF-8",
+            "params": [],
+            "text": "[object Object]"
+          },
           "queryString": [],
-          "url": "https://jsonplaceholder.typicode.com/todos/1"
+          "url": "https://jsonplaceholder.typicode.com/posts/1"
         },
         "response": {
-          "bodySize": 2,
+          "bodySize": 287,
           "content": {
+            "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2,
-            "text": "{}"
+            "size": 287,
+            "text": "[\"H4sIAAAAAAAAA1SPS2oEQQxD93MKUetssp0b5A69cVwKY+j6jMseJoTcPXRDCAEjJJAf6OsClFz0t1queH05ov3ZsNhZrigre0Ay8CFKJ5yT+y6B6eNhlT0wVIUqYeBTOSPdMGbYOMrOG3ulW5QT/D7q58G9pwkYWLnUpsXWfx2cmkt6FUJHX7xn9kgHn5PV4nzTbFv/h0cbO1eYEBnH3VMWYoS0rfexwrPBeSjXOYkN5zpnAx/sxoC43iyoMcrl+wcAAP//AwAVxg==\",\"k+gkAQAA\"]"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Sat, 24 Feb 2024 08:14:18 GMT"
+              "value": "Sun, 25 Feb 2024 09:57:24 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
             {
-              "name": "content-length",
-              "value": "2"
+              "name": "transfer-encoding",
+              "value": "chunked"
             },
             {
               "name": "connection",
@@ -215,11 +229,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708762458&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=4s7zsw0x4QfpghXk5ikNJv3pQIBVAnD%2BzYCbQaJZTfY%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708855044&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=PIIYvN%2BeTZZNT09X8tsjQFrTtQVRAKUkcoIw5IaC2qA%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708762458&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=4s7zsw0x4QfpghXk5ikNJv3pQIBVAnD%2BzYCbQaJZTfY%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708855044&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=PIIYvN%2BeTZZNT09X8tsjQFrTtQVRAKUkcoIw5IaC2qA%3D"
             },
             {
               "name": "nel",
@@ -235,11 +249,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "998"
+              "value": "997"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1708762472"
+              "value": "1708855066"
             },
             {
               "name": "access-control-allow-origin",
@@ -271,7 +285,7 @@
             },
             {
               "name": "etag",
-              "value": "W/\"2-vyGp6PvFo4RvsFtPoIWeCReyIC8\""
+              "value": "W/\"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU\""
             },
             {
               "name": "via",
@@ -287,21 +301,25 @@
             },
             {
               "name": "cf-ray",
-              "value": "85a64117585f214a-MAD"
+              "value": "85af157accf569ea-MAD"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1111,
+          "headersSize": 1146,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-24T08:14:18.668Z",
-        "time": 112,
+        "startedDateTime": "2024-02-25T09:57:23.272Z",
+        "time": 1092,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -309,7 +327,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 112
+          "wait": 1092
         }
       }
     ],

--- a/test/records/FetchClient .post performs POST request/recordings_613089741/recording.har
+++ b/test/records/FetchClient .post performs POST request/recordings_613089741/recording.har
@@ -1,0 +1,202 @@
+{
+  "log": {
+    "_recordingName": "recordings",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "7103348f0a98b9cf5f2961f29371dc38",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 15,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "text/plain;charset=UTF-8"
+            },
+            {
+              "name": "referer",
+              "value": "http://localhost/"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3"
+            },
+            {
+              "name": "accept-language",
+              "value": "en"
+            },
+            {
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "name": "origin",
+              "value": "http://localhost"
+            },
+            {
+              "name": "content-length",
+              "value": 15
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "host",
+              "value": "jsonplaceholder.typicode.com"
+            }
+          ],
+          "headersSize": 362,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "text/plain;charset=UTF-8",
+            "params": [],
+            "text": "[object Object]"
+          },
+          "queryString": [],
+          "url": "https://jsonplaceholder.typicode.com/posts"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 15,
+            "text": "{\n  \"id\": 101\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Sun, 25 Feb 2024 09:57:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708855043&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=hL7Pvxu4%2FwVfvJ5Nmm%2FxvrPcqxu9CgZ8xkFtVOVyOGc%3D\"}]}"
+            },
+            {
+              "name": "reporting-endpoints",
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708855043&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=hL7Pvxu4%2FwVfvJ5Nmm%2FxvrPcqxu9CgZ8xkFtVOVyOGc%3D"
+            },
+            {
+              "name": "nel",
+              "value": "{\"report_to\":\"heroku-nel\",\"max_age\":3600,\"success_fraction\":0.005,\"failure_fraction\":0.05,\"response_headers\":[\"Via\"]}"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "Express"
+            },
+            {
+              "name": "x-ratelimit-limit",
+              "value": "1000"
+            },
+            {
+              "name": "x-ratelimit-remaining",
+              "value": "999"
+            },
+            {
+              "name": "x-ratelimit-reset",
+              "value": "1708855066"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "http://localhost"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, X-HTTP-Method-Override, Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "Location"
+            },
+            {
+              "name": "location",
+              "value": "https://jsonplaceholder.typicode.com/posts/101"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"f-4jjw4Y8q22Yv1PV9m28FczJgjzk\""
+            },
+            {
+              "name": "via",
+              "value": "1.1 vegur"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "85af1572aae7214d-MAD"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
+            }
+          ],
+          "headersSize": 1239,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://jsonplaceholder.typicode.com/posts/101",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2024-02-25T09:57:22.918Z",
+        "time": 161,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 161
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/records/FetchClient .put performs PUT request/recordings_613089741/recording.har
+++ b/test/records/FetchClient .put performs PUT request/recordings_613089741/recording.har
@@ -1,6 +1,6 @@
 {
   "log": {
-    "_recordingName": "#makeRequest",
+    "_recordingName": "recordings",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "3b67edba340ffbcc6e8ed5ddcf3fe94d",
+        "_id": "83cdb6e8a95c44bcd4725b068961511d",
         "_order": 0,
         "cache": {},
         "request": {
@@ -25,7 +25,7 @@
             },
             {
               "name": "access-control-request-method",
-              "value": "PATCH"
+              "value": "PUT"
             },
             {
               "name": "user-agent",
@@ -36,7 +36,7 @@
               "value": "jsonplaceholder.typicode.com"
             }
           ],
-          "headersSize": 279,
+          "headersSize": 277,
           "httpVersion": "HTTP/1.1",
           "method": "OPTIONS",
           "queryString": [],
@@ -52,7 +52,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Sat, 24 Feb 2024 08:12:46 GMT"
+              "value": "Sun, 25 Feb 2024 09:57:25 GMT"
             },
             {
               "name": "content-length",
@@ -64,11 +64,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708762366&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=xZOoiVFt1ngQuszoE%2FVNL2cvAUFQfIOmlEocKR4qH30%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708855045&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=706k0NhVLgdc3wixnZigUqj9oMOPDXlzApjrbLa0a3M%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708762366&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=xZOoiVFt1ngQuszoE%2FVNL2cvAUFQfIOmlEocKR4qH30%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708855045&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=706k0NhVLgdc3wixnZigUqj9oMOPDXlzApjrbLa0a3M%3D"
             },
             {
               "name": "nel",
@@ -84,11 +84,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "998"
+              "value": "996"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1708762412"
+              "value": "1708855066"
             },
             {
               "name": "access-control-allow-origin",
@@ -120,21 +120,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85a63ed4bb493846-MAD"
+              "value": "85af15818dbf2f8b-MAD"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1011,
+          "headersSize": 1007,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 204,
           "statusText": "No Content"
         },
-        "startedDateTime": "2024-02-24T08:12:46.061Z",
-        "time": 141,
+        "startedDateTime": "2024-02-25T09:57:24.385Z",
+        "time": 1063,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -142,11 +142,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 141
+          "wait": 1063
         }
       },
       {
-        "_id": "131009a3a9feea658907944892945ed2",
+        "_id": "449b8fa427f25f284537287a54949c90",
         "_order": 0,
         "cache": {},
         "request": {
@@ -190,9 +190,9 @@
               "value": "jsonplaceholder.typicode.com"
             }
           ],
-          "headersSize": 365,
+          "headersSize": 363,
           "httpVersion": "HTTP/1.1",
-          "method": "PATCH",
+          "method": "PUT",
           "postData": {
             "mimeType": "text/plain;charset=UTF-8",
             "params": [],
@@ -202,26 +202,25 @@
           "url": "https://jsonplaceholder.typicode.com/posts/1"
         },
         "response": {
-          "bodySize": 287,
+          "bodySize": 13,
           "content": {
-            "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 287,
-            "text": "[\"H4sIAAAAAAAAA1SPS2oEQQxD93MKUetssp0b5A69cVwKY+j6jMseJoTcPXRDCAEjJJAf6OsClFz0t1queH05ov3ZsNhZrigre0Ay8CFKJ5yT+y6B6eNhlT0wVIUqYeBTOSPdMGbYOMrOG3ulW5QT/D7q58G9pwkYWLnUpsXWfx2cmkt6FUJHX7xn9kgHn5PV4nzTbFv/h0cbO1eYEBnH3VMWYoS0rfexwrPBeSjXOYkN5zpnAx/sxoC43iyoMcrl+wcAAP//AwAVxg==\",\"k+gkAQAA\"]"
+            "size": 13,
+            "text": "{\n  \"id\": 1\n}"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Sat, 24 Feb 2024 08:12:46 GMT"
+              "value": "Sun, 25 Feb 2024 09:57:25 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
+              "name": "content-length",
+              "value": "13"
             },
             {
               "name": "connection",
@@ -229,11 +228,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708762366&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=xZOoiVFt1ngQuszoE%2FVNL2cvAUFQfIOmlEocKR4qH30%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708855045&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=706k0NhVLgdc3wixnZigUqj9oMOPDXlzApjrbLa0a3M%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708762366&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=xZOoiVFt1ngQuszoE%2FVNL2cvAUFQfIOmlEocKR4qH30%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708855045&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=706k0NhVLgdc3wixnZigUqj9oMOPDXlzApjrbLa0a3M%3D"
             },
             {
               "name": "nel",
@@ -249,11 +248,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "997"
+              "value": "995"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1708762412"
+              "value": "1708855066"
             },
             {
               "name": "access-control-allow-origin",
@@ -285,7 +284,7 @@
             },
             {
               "name": "etag",
-              "value": "W/\"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU\""
+              "value": "W/\"d-p13Thq1mbIznE8TsFv4BmW8SRpg\""
             },
             {
               "name": "via",
@@ -301,25 +300,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85a63ed56c4f3846-MAD"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
+              "value": "85af15823e972f8b-MAD"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1146,
+          "headersSize": 1108,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-24T08:12:46.207Z",
-        "time": 107,
+        "startedDateTime": "2024-02-25T09:57:25.451Z",
+        "time": 278,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -327,7 +322,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 107
+          "wait": 278
         }
       }
     ],

--- a/test/records/NodeClient .delete performs DELETE request/recordings_613089741/recording.har
+++ b/test/records/NodeClient .delete performs DELETE request/recordings_613089741/recording.har
@@ -1,0 +1,158 @@
+{
+  "log": {
+    "_recordingName": "recordings",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "99e7e3bd2905d51feabc228ffff84431",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 4,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "jsonplaceholder.typicode.com"
+            }
+          ],
+          "headersSize": 100,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "null"
+          },
+          "queryString": [],
+          "url": "https://jsonplaceholder.typicode.com/todos/1"
+        },
+        "response": {
+          "bodySize": 2,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2,
+            "text": "{}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Sun, 25 Feb 2024 10:24:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708856693&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=f44JotPyBqn8ZlN60s7LN34QK51QtGpt1%2BjOdutw%2F6s%3D\"}]}"
+            },
+            {
+              "name": "reporting-endpoints",
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708856693&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=f44JotPyBqn8ZlN60s7LN34QK51QtGpt1%2BjOdutw%2F6s%3D"
+            },
+            {
+              "name": "nel",
+              "value": "{\"report_to\":\"heroku-nel\",\"max_age\":3600,\"success_fraction\":0.005,\"failure_fraction\":0.05,\"response_headers\":[\"Via\"]}"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "Express"
+            },
+            {
+              "name": "x-ratelimit-limit",
+              "value": "1000"
+            },
+            {
+              "name": "x-ratelimit-remaining",
+              "value": "996"
+            },
+            {
+              "name": "x-ratelimit-reset",
+              "value": "1708856746"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"2-vyGp6PvFo4RvsFtPoIWeCReyIC8\""
+            },
+            {
+              "name": "via",
+              "value": "1.1 vegur"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "85af3dc0dbb75e48-MAD"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
+            }
+          ],
+          "headersSize": 1068,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-02-25T10:24:53.864Z",
+        "time": 128,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 128
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/records/NodeClient .get performs GET request/recordings_613089741/recording.har
+++ b/test/records/NodeClient .get performs GET request/recordings_613089741/recording.har
@@ -1,0 +1,166 @@
+{
+  "log": {
+    "_recordingName": "recordings",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ebc587d17fa177f5e19f1075535c607e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 4,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "jsonplaceholder.typicode.com"
+            }
+          ],
+          "headersSize": 97,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "null"
+          },
+          "queryString": [],
+          "url": "https://jsonplaceholder.typicode.com/todos/1"
+        },
+        "response": {
+          "bodySize": 83,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 83,
+            "text": "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"delectus aut autem\",\n  \"completed\": false\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Sun, 25 Feb 2024 10:24:52 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "83"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708476221&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=9e%2BoOw%2Fe6tako5b%2BcKIrbLPd%2BJZBxrDeFtQ914BeJJ4%3D\"}]}"
+            },
+            {
+              "name": "reporting-endpoints",
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708476221&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=9e%2BoOw%2Fe6tako5b%2BcKIrbLPd%2BJZBxrDeFtQ914BeJJ4%3D"
+            },
+            {
+              "name": "nel",
+              "value": "{\"report_to\":\"heroku-nel\",\"max_age\":3600,\"success_fraction\":0.005,\"failure_fraction\":0.05,\"response_headers\":[\"Via\"]}"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "Express"
+            },
+            {
+              "name": "x-ratelimit-limit",
+              "value": "1000"
+            },
+            {
+              "name": "x-ratelimit-remaining",
+              "value": "999"
+            },
+            {
+              "name": "x-ratelimit-reset",
+              "value": "1708476281"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "cache-control",
+              "value": "max-age=43200"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"53-hfEnumeNh6YirfjyjaujcOPPT+s\""
+            },
+            {
+              "name": "via",
+              "value": "1.1 vegur"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "HIT"
+            },
+            {
+              "name": "age",
+              "value": "495"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "85af3dba8da42fb7-MAD"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
+            }
+          ],
+          "headersSize": 1111,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-02-25T10:24:52.122Z",
+        "time": 769,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 769
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/records/NodeClient .patch performs PATCH request/recordings_613089741/recording.har
+++ b/test/records/NodeClient .patch performs PATCH request/recordings_613089741/recording.har
@@ -1,0 +1,158 @@
+{
+  "log": {
+    "_recordingName": "recordings",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "c2e5075910a6df974899a45a9eccaf81",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 15,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "jsonplaceholder.typicode.com"
+            }
+          ],
+          "headersSize": 99,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "{\"title\":\"foo\"}"
+          },
+          "queryString": [],
+          "url": "https://jsonplaceholder.typicode.com/posts/1"
+        },
+        "response": {
+          "bodySize": 292,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 292,
+            "text": "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Sun, 25 Feb 2024 10:24:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "292"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708856693&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=f44JotPyBqn8ZlN60s7LN34QK51QtGpt1%2BjOdutw%2F6s%3D\"}]}"
+            },
+            {
+              "name": "reporting-endpoints",
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708856693&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=f44JotPyBqn8ZlN60s7LN34QK51QtGpt1%2BjOdutw%2F6s%3D"
+            },
+            {
+              "name": "nel",
+              "value": "{\"report_to\":\"heroku-nel\",\"max_age\":3600,\"success_fraction\":0.005,\"failure_fraction\":0.05,\"response_headers\":[\"Via\"]}"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "Express"
+            },
+            {
+              "name": "x-ratelimit-limit",
+              "value": "1000"
+            },
+            {
+              "name": "x-ratelimit-remaining",
+              "value": "998"
+            },
+            {
+              "name": "x-ratelimit-reset",
+              "value": "1708856746"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU\""
+            },
+            {
+              "name": "via",
+              "value": "1.1 vegur"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "85af3dbd98245e48-MAD"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
+            }
+          ],
+          "headersSize": 1072,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-02-25T10:24:53.346Z",
+        "time": 126,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 126
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/records/NodeClient .post performs POST request/recordings_613089741/recording.har
+++ b/test/records/NodeClient .post performs POST request/recordings_613089741/recording.har
@@ -1,0 +1,166 @@
+{
+  "log": {
+    "_recordingName": "recordings",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ac20dd5c5d58cc64b612b53d1c210c83",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 39,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "jsonplaceholder.typicode.com"
+            }
+          ],
+          "headersSize": 96,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "{\"title\":\"foo\",\"body\":\"bar\",\"userId\":1}"
+          },
+          "queryString": [],
+          "url": "https://jsonplaceholder.typicode.com/posts"
+        },
+        "response": {
+          "bodySize": 15,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 15,
+            "text": "{\n  \"id\": 101\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Sun, 25 Feb 2024 10:24:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "15"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "report-to",
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708856693&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=f44JotPyBqn8ZlN60s7LN34QK51QtGpt1%2BjOdutw%2F6s%3D\"}]}"
+            },
+            {
+              "name": "reporting-endpoints",
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708856693&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=f44JotPyBqn8ZlN60s7LN34QK51QtGpt1%2BjOdutw%2F6s%3D"
+            },
+            {
+              "name": "nel",
+              "value": "{\"report_to\":\"heroku-nel\",\"max_age\":3600,\"success_fraction\":0.005,\"failure_fraction\":0.05,\"response_headers\":[\"Via\"]}"
+            },
+            {
+              "name": "x-powered-by",
+              "value": "Express"
+            },
+            {
+              "name": "x-ratelimit-limit",
+              "value": "1000"
+            },
+            {
+              "name": "x-ratelimit-remaining",
+              "value": "999"
+            },
+            {
+              "name": "x-ratelimit-reset",
+              "value": "1708856746"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, X-HTTP-Method-Override, Accept-Encoding"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "-1"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "Location"
+            },
+            {
+              "name": "location",
+              "value": "https://jsonplaceholder.typicode.com/posts/101"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"f-4jjw4Y8q22Yv1PV9m28FczJgjzk\""
+            },
+            {
+              "name": "via",
+              "value": "1.1 vegur"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "85af3dbb4dad5e48-MAD"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=86400"
+            }
+          ],
+          "headersSize": 1192,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "https://jsonplaceholder.typicode.com/posts/101",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2024-02-25T10:24:52.904Z",
+        "time": 433,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 433
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/records/NodeClient .put performs PUT request/recordings_613089741/recording.har
+++ b/test/records/NodeClient .put performs PUT request/recordings_613089741/recording.har
@@ -1,6 +1,6 @@
 {
   "log": {
-    "_recordingName": "#makeRequest",
+    "_recordingName": "recordings",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
@@ -8,69 +8,49 @@
     },
     "entries": [
       {
-        "_id": "76ae98e64be2b0371c8c4afb83c94963",
+        "_id": "0a728b6a6d05bcb9792604c9f8e0de49",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 0,
+          "bodySize": 46,
           "cookies": [],
           "headers": [
-            {
-              "name": "referer",
-              "value": "http://localhost/"
-            },
-            {
-              "name": "user-agent",
-              "value": "Mozilla/5.0 (darwin) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/20.0.3"
-            },
-            {
-              "name": "accept-language",
-              "value": "en"
-            },
-            {
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "name": "origin",
-              "value": "http://localhost"
-            },
-            {
-              "name": "accept-encoding",
-              "value": "gzip, deflate"
-            },
             {
               "name": "host",
               "value": "jsonplaceholder.typicode.com"
             }
           ],
-          "headersSize": 303,
+          "headersSize": 97,
           "httpVersion": "HTTP/1.1",
-          "method": "GET",
+          "method": "PUT",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "{\"id\":1,\"title\":\"foo\",\"body\":\"bar\",\"userId\":1}"
+          },
           "queryString": [],
-          "url": "https://jsonplaceholder.typicode.com/todos/1"
+          "url": "https://jsonplaceholder.typicode.com/posts/1"
         },
         "response": {
-          "bodySize": 120,
+          "bodySize": 13,
           "content": {
-            "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 120,
-            "text": "[\"H4sIAAAAAAAAA6vmUlBQKi1OLfJMUbJSMNQBcTMRzJLMkpxUJSsFpZTUnNTkktJihcTSEhBOzVUCK0jOzy3ISS1JBWlJS8wpTuWqBQA33AG3UwAAAA==\"]"
+            "size": 13,
+            "text": "{\n  \"id\": 1\n}"
           },
           "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Sat, 24 Feb 2024 08:12:45 GMT"
+              "value": "Sun, 25 Feb 2024 10:24:53 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json; charset=utf-8"
             },
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
+              "name": "content-length",
+              "value": "13"
             },
             {
               "name": "connection",
@@ -78,11 +58,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1701246421&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=YIBcmrQEvdKrJNcKQ%2FmwapuaBUkeTFjzF%2FPruKnJRWw%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708856693&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=f44JotPyBqn8ZlN60s7LN34QK51QtGpt1%2BjOdutw%2F6s%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1701246421&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=YIBcmrQEvdKrJNcKQ%2FmwapuaBUkeTFjzF%2FPruKnJRWw%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708856693&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=f44JotPyBqn8ZlN60s7LN34QK51QtGpt1%2BjOdutw%2F6s%3D"
             },
             {
               "name": "nel",
@@ -98,15 +78,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "999"
+              "value": "997"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1701246464"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": "http://localhost"
+              "value": "1708856746"
             },
             {
               "name": "vary",
@@ -118,7 +94,7 @@
             },
             {
               "name": "cache-control",
-              "value": "max-age=43200"
+              "value": "no-cache"
             },
             {
               "name": "pragma",
@@ -134,7 +110,7 @@
             },
             {
               "name": "etag",
-              "value": "W/\"53-hfEnumeNh6YirfjyjaujcOPPT+s\""
+              "value": "W/\"d-p13Thq1mbIznE8TsFv4BmW8SRpg\""
             },
             {
               "name": "via",
@@ -142,11 +118,7 @@
             },
             {
               "name": "cf-cache-status",
-              "value": "HIT"
-            },
-            {
-              "name": "age",
-              "value": "5138"
+              "value": "DYNAMIC"
             },
             {
               "name": "server",
@@ -154,25 +126,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85a63ed2fb353851-MAD"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
+              "value": "85af3dbe89075e48-MAD"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1069,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-24T08:12:44.918Z",
-        "time": 931,
+        "startedDateTime": "2024-02-25T10:24:53.479Z",
+        "time": 372,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -180,7 +148,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 931
+          "wait": 372
         }
       }
     ],


### PR DESCRIPTION
Adds new HTTP client which uses `Node` `https` to perform HTTP requests.

This will be useful to test the reMarkable API integration in a node environment.