### PR TITLE
chore: refactor re-used constants in its own file

### DIFF
--- a/src/authentication/Device.ts
+++ b/src/authentication/Device.ts
@@ -1,10 +1,7 @@
 import DeviceToken from './DeviceToken'
 import NodeClient from '../net/NodeClient'
 import { DeviceDescription } from './DeviceDescription'
-
-const REMARKABLE_HOST: string = 'https://webapp-prod.cloud.remarkable.engineering'
-const PAIR_PATH: string = '/token/json/2/device/new'
-const SESSION_PATH: string = '/token/json/2/user/new'
+import { PAIR_PATH, REMARKABLE_HOST, SESSION_PATH } from '../constants'
 
 export default class Device {
   public static async pair(id: string, description: DeviceDescription, oneTimeCode: string): Promise<Device> {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+export const REMARKABLE_HOST: string = 'https://webapp-prod.cloud.remarkable.engineering'
+export const PAIR_PATH: string = '/token/json/2/device/new'
+export const SESSION_PATH: string = '/token/json/2/user/new'


### PR DESCRIPTION
Define a `constants.ts` file to hold all project constants. Replace all in-place uses of constants with new exported constants from `constants.ts`.