### PR TITLE
chore: Linter Job in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,27 @@ jobs:
 
       - name: Run tests
         run: yarn test
+  lint:
+    environment: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '21.5.0'
+          cache: 'yarn'
+
+      - name: Install Dependencies
+        run: yarn install --pure-lockfile
+
+      - name: Load linter cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/eslint/
+          key: ${{ runner.os }}-eslint-${{ hashFiles('**/package-lock.json', '**/.eslintrc') }}
+
+      - name: Run tests
+        run: yarn lint --cache --cache-strategy content --cache-location ~/.cache/eslint/current


### PR DESCRIPTION
This job runs the `package.json` `lint` script, which uses `ESLint` underneath.

To speed up the process I added a `--cache` option. This option generates a file with linter results, so in subsequent jobs only new/modified files are checked.

Our cache key is configured with the package-json and eslintrc configuration files, so whenever they are updated the cache is regenerated.