### PR TITLE
chore: test environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
           node-version: '21.5.0'
           cache: 'yarn'
 
+      - name: Set up environment variables
+        run: |
+          echo SAMPLE_UUID=${{ secrets.SAMPLE_UUID }} >> .env.test
+          echo SAMPLE_PAIR_TOKEN=${{ secrets.SAMPLE_PAIR_TOKEN }} >> .env.test
+
       - name: Install Dependencies
         run: yarn install --pure-lockfile
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 
 # Ignore IDE configuration files
 .idea/
+
+# Ignore test environment variables
+.env.test

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/jest": "^29.5.12",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
+    "dotenv": "^16.4.5",
     "esbuild": "^0.20.0",
     "eslint": "^8.57.0",
     "eslint-config-standard-with-typescript": "^43.0.1",

--- a/test/authentication/Device.test.ts
+++ b/test/authentication/Device.test.ts
@@ -1,14 +1,9 @@
 /**
  * @jest-environment node
  */
-
 import Device from '../../src/authentication/Device'
 import { setupHttpRecording } from '../helpers/pollyHelpers'
 import DeviceToken from '../../src/authentication/DeviceToken'
-
-// const SAMPLE_ONE_TIME_CODE: string = 'cfdaemci'
-const SAMPLE_UUID: string = '02ce7950-0b1e-4039-95a7-e098e10c33fa'
-const SAMPLE_PAIR_TOKEN: DeviceToken = new DeviceToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdXRoMC11c2VyaWQiOiJhdXRoMHw1ZWZjMjg3ZmM0ODgwMTAwMTM0NGY5MjMiLCJkZXZpY2UtZGVzYyI6ImJyb3dzZXItY2hyb21lIiwiZGV2aWNlLWlkIjoiMDJjZTc5NTAtMGIxZS00MDM5LTk1YTctZTA5OGUxMGMzM2ZhIiwiaWF0IjoxNzA5MDE2NTk3LCJpc3MiOiJyTSBXZWJBcHAiLCJqdGkiOiJjazB0S2FFdFM4MD0iLCJuYmYiOjE3MDkwMTY1OTcsInN1YiI6InJNIERldmljZSBUb2tlbiJ9.vO5iXB-Xy1cbpn8HeZmt5NYyI3wytnPxYp2-2WggFhU')
 
 describe('Device', () => {
   // Enables Polly.js to record and replay HTTP requests for each test
@@ -35,11 +30,15 @@ describe('Device', () => {
     it(
       'given valid pair token, updates Device with new session token',
       async () => {
-        const device = new Device(SAMPLE_UUID, 'browser-chrome', SAMPLE_PAIR_TOKEN)
+        const device = new Device(
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          process.env.SAMPLE_UUID!, 'browser-chrome', new DeviceToken(process.env.SAMPLE_PAIR_TOKEN!)
+        )
 
         await device.connect()
 
-        expect(device.sessionToken.deviceId).toBe(SAMPLE_UUID)
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(device.sessionToken.deviceId).toBe(process.env.SAMPLE_UUID!)
         expect(device.sessionToken.deviceDescription).toBe('browser-chrome')
       },
       30000

--- a/test/authentication/DeviceToken.test.ts
+++ b/test/authentication/DeviceToken.test.ts
@@ -1,13 +1,14 @@
 import DeviceToken from '../../src/authentication/DeviceToken'
 
-const SAMPLE_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdXRoMC11c2VyaWQiOiJhdXRoMHw1ZWZjMjg3ZmM0ODgwMTAwMTM0NGY5MjMiLCJkZXZpY2UtZGVzYyI6ImJyb3dzZXItY2hyb21lIiwiZGV2aWNlLWlkIjoiZmQwNDNkNGItYWUzNy00NTJlLThkMjAtNmE1MGVkY2M0YmZjIiwiaWF0IjoxNzA4OTM0MDAyLCJpc3MiOiJyTSBXZWJBcHAiLCJqdGkiOiJjazB0dXhrbkhQOD0iLCJuYmYiOjE3MDg5MzQwMDIsInN1YiI6InJNIERldmljZSBUb2tlbiJ9.Tbb557AZHRCO4BFmTKXm1jDNRV9PdjMWTwZPo9eDYzw'
-
 describe('DeviceToken', () => {
   it('given a valid token, returns token with device information', () => {
-    const token = new DeviceToken(SAMPLE_TOKEN)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const token = new DeviceToken(process.env.SAMPLE_PAIR_TOKEN!)
 
-    expect(token.token).toBe(SAMPLE_TOKEN)
-    expect(token.deviceId).toBe('fd043d4b-ae37-452e-8d20-6a50edcc4bfc')
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(token.token).toBe(process.env.SAMPLE_PAIR_TOKEN!)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(token.deviceId).toBe(process.env.SAMPLE_UUID!)
     expect(token.deviceDescription).toBe('browser-chrome')
     expect(token.issuer).toBe('rM WebApp')
     expect(token.subject).toBe('rM Device Token')

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,7 +1,4 @@
-/**
- * Polly.js Configuration
- * ----------------------
- */
+import * as dotenv from 'dotenv'
 
 /**
  * JSDom Jest Environment does not support fetch API. This is a workaround to make it work in our tests.
@@ -19,6 +16,21 @@ import 'whatwg-fetch'
 import { Polly } from '@pollyjs/core'
 import * as FSPersister from '@pollyjs/persister-fs'
 import * as NodeHttpAdapter from '@pollyjs/adapter-node-http'
+
+/**
+ * DotEnv Configuration
+ * --------------------
+ */
+
+/**
+ * Load environment variables from .env.test file
+ */
+dotenv.config({ path: '.env.test' })
+
+/**
+ * Polly.js Configuration
+ * ----------------------
+ */
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error

--- a/test/serviceDiscovery/ServiceDiscovery.test.ts
+++ b/test/serviceDiscovery/ServiceDiscovery.test.ts
@@ -3,16 +3,16 @@ import DeviceToken from '../../src/authentication/DeviceToken'
 import ServiceDiscovery from '../../src/serviceDiscovery/ServiceDiscovery'
 import { setupHttpRecording } from '../helpers/pollyHelpers'
 
-const SAMPLE_UUID: string = '02ce7950-0b1e-4039-95a7-e098e10c33fa'
-const SAMPLE_PAIR_TOKEN: DeviceToken = new DeviceToken('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdXRoMC11c2VyaWQiOiJhdXRoMHw1ZWZjMjg3ZmM0ODgwMTAwMTM0NGY5MjMiLCJkZXZpY2UtZGVzYyI6ImJyb3dzZXItY2hyb21lIiwiZGV2aWNlLWlkIjoiMDJjZTc5NTAtMGIxZS00MDM5LTk1YTctZTA5OGUxMGMzM2ZhIiwiaWF0IjoxNzA5MDE2NTk3LCJpc3MiOiJyTSBXZWJBcHAiLCJqdGkiOiJjazB0S2FFdFM4MD0iLCJuYmYiOjE3MDkwMTY1OTcsInN1YiI6InJNIERldmljZSBUb2tlbiJ9.vO5iXB-Xy1cbpn8HeZmt5NYyI3wytnPxYp2-2WggFhU')
-
 describe('ServiceDiscovery', () => {
   // Enables Polly.js to record and replay HTTP requests for each test
   setupHttpRecording()
 
   describe('.discoverStorageHost', () => {
     it('if Device is connected, updates service discovery with storage host', async () => {
-      const device = new Device(SAMPLE_UUID, 'browser-chrome', SAMPLE_PAIR_TOKEN)
+      const device = new Device(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        process.env.SAMPLE_UUID!, 'browser-chrome', new DeviceToken(process.env.SAMPLE_PAIR_TOKEN!)
+      )
 
       await device.connect()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1880,6 +1880,11 @@ domexception@^4.0.0:
   dependencies:
     webidl-conversions "^7.0.0"
 
+dotenv@^16.4.5:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION
Updates test configuration with `dotenv` to read sensible information (IDs, tokens, etc) from a secret file. This way, information can be kept hidden from the repository.