### PR TITLE
feature: http client context

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,0 @@
-export const AUTHENTICATION_HOST: string = 'https://webapp-prod.cloud.remarkable.engineering'
-export const PAIR_PATH: string = '/token/json/2/device/new'
-export const SESSION_PATH: string = '/token/json/2/user/new'
-export const SERVICE_DISCOVERY_HOST: string = 'https://service-manager-production-dot-remarkable-production.appspot.com'
-export const STORAGE_DISCOVERY_PATH: string = '/service/json/1/document-storage?environment=production&group=auth0%7C5a68dc51cb30df3877a1d7c4&apiVer=2'
-export const STORAGE_HOST: string = 'https://document-storage-production-dot-remarkable-production.appspot.com'

--- a/src/net/HttpClient.ts
+++ b/src/net/HttpClient.ts
@@ -1,4 +1,4 @@
-import HttpClientContext from './HttpClientContext'
+import type HttpClientContext from './HttpClientContext'
 
 /**
  * HTTP Client abstract class
@@ -78,8 +78,8 @@ export default abstract class HttpClient {
     path: string,
     context: HttpClientContext = this.context
   ): Promise<Response> {
-    return (this.constructor as any)
-      .get(context.host || this.context.host, path, context.headers || this.context.headers)
+    return await this.classReference()
+      .get(context.host ?? this.context.host, path, context.headers ?? this.context.headers)
   }
 
   public async post (
@@ -87,8 +87,8 @@ export default abstract class HttpClient {
     body: Record<string, string> = {},
     context: HttpClientContext = this.context
   ): Promise<Response> {
-    return (this.constructor as any)
-      .post(context.host || this.context.host, path, context.headers || this.context.headers, body)
+    return await this.classReference()
+      .post(context.host ?? this.context.host, path, context.headers ?? this.context.headers, body)
   }
 
   public async patch (
@@ -96,8 +96,8 @@ export default abstract class HttpClient {
     body: Record<string, string> = {},
     context: HttpClientContext = this.context
   ): Promise<Response> {
-    return (this.constructor as any)
-      .patch(context.host || this.context.host, path, context.headers || this.context.headers, body)
+    return await this.classReference()
+      .patch(context.host ?? this.context.host, path, context.headers ?? this.context.headers, body)
   }
 
   public async put (
@@ -105,15 +105,24 @@ export default abstract class HttpClient {
     body: Record<string, string> = {},
     context: HttpClientContext = this.context
   ): Promise<Response> {
-    return (this.constructor as any)
-      .put(context.host || this.context.host, path, context.headers || this.context.headers, body)
+    return await this.classReference()
+      .put(context.host ?? this.context.host, path, context.headers ?? this.context.headers, body)
   }
 
   public async delete (
     path: string,
     context: HttpClientContext = this.context
   ): Promise<Response> {
-    return (this.constructor as any)
-      .delete(context.host || this.context.host, path, context.headers || this.context.headers)
+    return await this.classReference()
+      .delete(context.host ?? this.context.host, path, context.headers ?? this.context.headers)
+  }
+
+  /**
+   * Get the class reference, used to invoke the respective static
+   * methods of the HttpClient subclass the instance belongs to.
+   * @private
+   */
+  private classReference (): typeof HttpClient {
+    return this.constructor as typeof HttpClient
   }
 }

--- a/src/net/HttpClient.ts
+++ b/src/net/HttpClient.ts
@@ -1,4 +1,29 @@
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+import HttpClientContext from './HttpClientContext'
+
+/**
+ * HTTP Client abstract class
+ *
+ * Defines interface for HTTP clients.
+ *
+ * Used by the different clients of the current library, to provide
+ * implementations of the HTTP interface with different libraries
+ * (https, fetch, etc).
+ *
+ * HTTP requests through client can be performed in two different ways:
+ *
+ * - If you are performing a specific HTTP requests with a host and headers
+ *   which are not used in other requests, you can use the static methods
+ *   of the client (get, post, patch, put, delete).
+ *
+ * - If you are performing multiple requests to the same endpoint with
+ *   the same headers, you can create an instance and use the instance
+ *   methods (get, post, patch, put, delete). This way, you can perform
+ *   multiple requests to the same host/with the same headers without
+ *   specifying them every time.
+ *
+ * @abstract
+ * @class HttpClient - HTTP Client abstract class
+ */
 export default abstract class HttpClient {
   public static async get (
     host: string,
@@ -41,5 +66,54 @@ export default abstract class HttpClient {
     headers: Record<string, string> = {}
   ): Promise<Response> {
     throw new Error('HTTP Client does not implement delete static method')
+  }
+
+  readonly context: HttpClientContext
+
+  constructor (host: string, headers: Record<string, string> = {}) {
+    this.context = { host, headers }
+  }
+
+  public async get (
+    path: string,
+    context: HttpClientContext = this.context
+  ): Promise<Response> {
+    return (this.constructor as any)
+      .get(context.host || this.context.host, path, context.headers || this.context.headers)
+  }
+
+  public async post (
+    path: string,
+    body: Record<string, string> = {},
+    context: HttpClientContext = this.context
+  ): Promise<Response> {
+    return (this.constructor as any)
+      .post(context.host || this.context.host, path, context.headers || this.context.headers, body)
+  }
+
+  public async patch (
+    path: string,
+    body: Record<string, string> = {},
+    context: HttpClientContext = this.context
+  ): Promise<Response> {
+    return (this.constructor as any)
+      .patch(context.host || this.context.host, path, context.headers || this.context.headers, body)
+  }
+
+  public async put (
+    path: string,
+    body: Record<string, string> = {},
+    context: HttpClientContext = this.context
+  ): Promise<Response> {
+    return (this.constructor as any)
+      .put(context.host || this.context.host, path, context.headers || this.context.headers, body)
+  }
+
+  public async delete (
+    path: string,
+    context: HttpClientContext = this.context
+  ): Promise<Response> {
+    return (this.constructor as any)
+      .delete(context.host || this.context.host, path, context.headers || this.context.headers)
   }
 }

--- a/src/net/HttpClientContext.ts
+++ b/src/net/HttpClientContext.ts
@@ -1,0 +1,16 @@
+/**
+ * Represents the context of an HTTP client.
+ *
+ * Given an instance of an `HttpClient` with a given `HttpContext`, the client will perform
+ * all requests to the given context host and with the given context headers (if specified).
+ * This way a client can perform multiple requests to different paths reusing the same
+ * context parameters.
+ *
+ * @interface HttpClientContext
+ * @property {string} host - The host of the context. All client HTTP requests will be performed to this host.
+ * @property {Headers} [headers] - The headers of the context. All client HTTP requests will be performed with these headers.
+ */
+export default interface HttpClientContext {
+  readonly host?: string
+  readonly headers?: Record<string, string>
+}

--- a/test/net/HttpClient.test.ts
+++ b/test/net/HttpClient.test.ts
@@ -1,5 +1,5 @@
 import HttpClient from '../../src/net/HttpClient'
-import HttpClientContext from '../../src/net/HttpClientContext'
+import type HttpClientContext from '../../src/net/HttpClientContext'
 
 /**
  * Test HTTP client used to test the behavior of HttpClient instances
@@ -16,7 +16,7 @@ class TestHttpClient extends HttpClient {
     path: string,
     headers: Record<string, string> = {}
   ): Promise<Response> {
-    return Promise.resolve(this.mockResponse('get', host, path, headers))
+    return await Promise.resolve(this.mockResponse('get', host, path, headers))
   }
 
   public static async post (
@@ -25,7 +25,7 @@ class TestHttpClient extends HttpClient {
     headers: Record<string, string> = {},
     body: Record<string, string> = {}
   ): Promise<Response> {
-    return Promise.resolve(this.mockResponse('post', host, path, headers, body))
+    return await Promise.resolve(this.mockResponse('post', host, path, headers, body))
   }
 
   public static async patch (
@@ -34,7 +34,7 @@ class TestHttpClient extends HttpClient {
     headers: Record<string, string> = {},
     body: Record<string, string> = {}
   ): Promise<Response> {
-    return Promise.resolve(this.mockResponse('patch', host, path, headers, body))
+    return await Promise.resolve(this.mockResponse('patch', host, path, headers, body))
   }
 
   public static async put (
@@ -43,7 +43,7 @@ class TestHttpClient extends HttpClient {
     headers: Record<string, string> = {},
     body: Record<string, string> = {}
   ): Promise<Response> {
-    return Promise.resolve(this.mockResponse('put', host, path, headers, body))
+    return await Promise.resolve(this.mockResponse('put', host, path, headers, body))
   }
 
   public static async delete (
@@ -51,7 +51,7 @@ class TestHttpClient extends HttpClient {
     path: string,
     headers: Record<string, string> = {}
   ): Promise<Response> {
-    return Promise.resolve(this.mockResponse('delete', host, path, headers))
+    return await Promise.resolve(this.mockResponse('delete', host, path, headers))
   }
 
   public static mockResponse (
@@ -69,12 +69,12 @@ class TestHttpClient extends HttpClient {
 }
 
 describe('HttpClient', () => {
-  let context: HttpClientContext = {
+  const context: HttpClientContext = {
     host: 'https://jsonplaceholder.typicode.com',
     headers: { Authorization: 'Bearer token' }
   }
 
-  let httpClient: TestHttpClient = new TestHttpClient(context.host, context.headers)
+  const httpClient: TestHttpClient = new TestHttpClient(context.host, context.headers)
 
   describe('.get', () => {
     it(
@@ -103,7 +103,7 @@ describe('HttpClient', () => {
           headers: { Authorization: 'Bearer otherToken' }
         }
 
-        const response = await httpClient.get( '/todos/1', otherContext)
+        const response = await httpClient.get('/todos/1', otherContext)
         const responseJson = await response.json()
 
         expect(responseJson).toEqual({
@@ -276,7 +276,7 @@ describe('HttpClient', () => {
           headers: { Authorization: 'Bearer otherToken' }
         }
 
-        const response = await httpClient.delete( '/todos/1', otherContext)
+        const response = await httpClient.delete('/todos/1', otherContext)
         const responseJson = await response.json()
 
         expect(responseJson).toEqual({

--- a/test/net/HttpClient.test.ts
+++ b/test/net/HttpClient.test.ts
@@ -1,0 +1,292 @@
+import HttpClient from '../../src/net/HttpClient'
+import HttpClientContext from '../../src/net/HttpClientContext'
+
+/**
+ * Test HTTP client used to test the behavior of HttpClient instances
+ *
+ * All HTTP interface methods returns a `Response` containing a stringified
+ * JSON with the request parameters. This way we can easily test instance
+ * methods are invoked with the right parameters.
+ *
+ * This test class also illustrates how an `HttpClient` subclass is defined.
+ */
+class TestHttpClient extends HttpClient {
+  public static async get (
+    host: string,
+    path: string,
+    headers: Record<string, string> = {}
+  ): Promise<Response> {
+    return Promise.resolve(this.mockResponse('get', host, path, headers))
+  }
+
+  public static async post (
+    host: string,
+    path: string,
+    headers: Record<string, string> = {},
+    body: Record<string, string> = {}
+  ): Promise<Response> {
+    return Promise.resolve(this.mockResponse('post', host, path, headers, body))
+  }
+
+  public static async patch (
+    host: string,
+    path: string,
+    headers: Record<string, string> = {},
+    body: Record<string, string> = {}
+  ): Promise<Response> {
+    return Promise.resolve(this.mockResponse('patch', host, path, headers, body))
+  }
+
+  public static async put (
+    host: string,
+    path: string,
+    headers: Record<string, string> = {},
+    body: Record<string, string> = {}
+  ): Promise<Response> {
+    return Promise.resolve(this.mockResponse('put', host, path, headers, body))
+  }
+
+  public static async delete (
+    host: string,
+    path: string,
+    headers: Record<string, string> = {}
+  ): Promise<Response> {
+    return Promise.resolve(this.mockResponse('delete', host, path, headers))
+  }
+
+  public static mockResponse (
+    method: string,
+    host: string,
+    path: string,
+    headers: Record<string, string> = {},
+    body: Record<string, string> = {}
+  ): Response {
+    return new Response(
+      JSON.stringify({ method, host, path, headers, body }),
+      { status: 200, statusText: 'OK' }
+    )
+  }
+}
+
+describe('HttpClient', () => {
+  let context: HttpClientContext = {
+    host: 'https://jsonplaceholder.typicode.com',
+    headers: { Authorization: 'Bearer token' }
+  }
+
+  let httpClient: TestHttpClient = new TestHttpClient(context.host, context.headers)
+
+  describe('.get', () => {
+    it(
+      'if context is specified and no host & headers are specified,' +
+            'performs GET request with context host and headers',
+      async () => {
+        const response = await httpClient.get('/todos/1')
+        const responseJson = await response.json()
+
+        expect(responseJson).toEqual({
+          method: 'get',
+          host: context.host,
+          path: '/todos/1',
+          headers: context.headers,
+          body: {}
+        })
+      }
+    )
+
+    it(
+      'if context is specified and host & headers are specified,' +
+            'performs GET request with specified host and headers',
+      async () => {
+        const otherContext: HttpClientContext = {
+          host: 'other',
+          headers: { Authorization: 'Bearer otherToken' }
+        }
+
+        const response = await httpClient.get( '/todos/1', otherContext)
+        const responseJson = await response.json()
+
+        expect(responseJson).toEqual({
+          method: 'get',
+          host: otherContext.host,
+          path: '/todos/1',
+          headers: otherContext.headers,
+          body: {}
+        })
+      }
+    )
+  })
+
+  describe('.post', () => {
+    it(
+      'if context is specified and no host & headers are specified,' +
+            'performs POST request with context host and headers',
+      async () => {
+        const body = { title: 'foo', body: 'bar' }
+
+        const response = await httpClient.post('/posts', body)
+        const responseJson = await response.json()
+
+        expect(responseJson).toEqual({
+          method: 'post',
+          host: context.host,
+          path: '/posts',
+          headers: context.headers,
+          body
+        })
+      }
+    )
+
+    it(
+      'if context is specified and host & headers are specified,' +
+            'performs POST request with specified host and headers',
+      async () => {
+        const otherContext: HttpClientContext = {
+          host: 'other',
+          headers: { Authorization: 'Bearer otherToken' }
+        }
+        const body = { title: 'foo', body: 'bar' }
+
+        const response = await httpClient.post('/posts', body, otherContext)
+        const responseJson = await response.json()
+
+        expect(responseJson).toEqual({
+          method: 'post',
+          host: otherContext.host,
+          path: '/posts',
+          headers: otherContext.headers,
+          body
+        })
+      }
+    )
+  })
+
+  describe('.patch', () => {
+    it(
+      'if context is specified and no host & headers are specified,' +
+            'performs PATCH request with context host and headers',
+      async () => {
+        const body = { title: 'foo' }
+
+        const response = await httpClient.patch('/posts/1', body)
+        const responseJson = await response.json()
+
+        expect(responseJson).toEqual({
+          method: 'patch',
+          host: context.host,
+          path: '/posts/1',
+          headers: context.headers,
+          body
+        })
+      }
+    )
+
+    it(
+      'if context is specified and host & headers are specified,' +
+            'performs PATCH request with specified host and headers',
+      async () => {
+        const otherContext: HttpClientContext = {
+          host: 'other',
+          headers: { Authorization: 'Bearer otherToken' }
+        }
+        const body = { title: 'foo' }
+
+        const response = await httpClient.patch('/posts', body, otherContext)
+        const responseJson = await response.json()
+
+        expect(responseJson).toEqual({
+          method: 'patch',
+          host: otherContext.host,
+          path: '/posts',
+          headers: otherContext.headers,
+          body
+        })
+      }
+    )
+  })
+
+  describe('.put', () => {
+    it(
+      'if context is specified and no host & headers are specified,' +
+            'performs PUT request with context host and headers',
+      async () => {
+        const body = { title: 'foo', body: 'bar' }
+
+        const response = await httpClient.put('/posts', body)
+        const responseJson = await response.json()
+
+        expect(responseJson).toEqual({
+          method: 'put',
+          host: context.host,
+          path: '/posts',
+          headers: context.headers,
+          body
+        })
+      }
+    )
+
+    it(
+      'if context is specified and host & headers are specified,' +
+            'performs PUT request with specified host and headers',
+      async () => {
+        const otherContext: HttpClientContext = {
+          host: 'other',
+          headers: { Authorization: 'Bearer otherToken' }
+        }
+        const body = { title: 'foo', body: 'bar' }
+
+        const response = await httpClient.put('/posts', body, otherContext)
+        const responseJson = await response.json()
+
+        expect(responseJson).toEqual({
+          method: 'put',
+          host: otherContext.host,
+          path: '/posts',
+          headers: otherContext.headers,
+          body
+        })
+      }
+    )
+  })
+
+  describe('.delete', () => {
+    it(
+      'if context is specified and no host & headers are specified,' +
+            'performs DELETE request with context host and headers',
+      async () => {
+        const response = await httpClient.delete('/todos/1')
+        const responseJson = await response.json()
+
+        expect(responseJson).toEqual({
+          method: 'delete',
+          host: context.host,
+          path: '/todos/1',
+          headers: context.headers,
+          body: {}
+        })
+      }
+    )
+
+    it(
+      'if context is specified and host & headers are specified,' +
+            'performs DELETE request with specified host and headers',
+      async () => {
+        const otherContext: HttpClientContext = {
+          host: 'other',
+          headers: { Authorization: 'Bearer otherToken' }
+        }
+
+        const response = await httpClient.delete( '/todos/1', otherContext)
+        const responseJson = await response.json()
+
+        expect(responseJson).toEqual({
+          method: 'delete',
+          host: otherContext.host,
+          path: '/todos/1',
+          headers: otherContext.headers,
+          body: {}
+        })
+      }
+    )
+  })
+})


### PR DESCRIPTION
Extend `HttpClient` class with `Contexts`.

Contexts hold HTTP request parameters that are re-used across multiple requests. Since it is pretty common for a module in our library to perform multiple requests with the same host and headers, this idea of `Contexts` improves the code quality significantly and removes redundancies.

This is going to be useful for upcoming PRs, to keep the logic for each independent module easier to understand.