### PR TITLE
fix: Http `Body` type adjustments.

### DIFF
--- a/src/net/FetchClient.ts
+++ b/src/net/FetchClient.ts
@@ -1,5 +1,6 @@
 import HttpClient from './HttpClient'
 import HttpClientRequest from './HttpClientRequest'
+import { type HttpClientRequestBodyPayload } from './HttpClientRequestBody'
 
 export default class FetchClient extends HttpClient {
   public static async get (
@@ -14,7 +15,7 @@ export default class FetchClient extends HttpClient {
     host: string,
     path: string,
     headers: Record<string, string> = {},
-    body: Record<string, string> = {}
+    body: HttpClientRequestBodyPayload | null = {}
   ): Promise<Response> {
     return await this.makeRequest(this.request(host, path, 'POST', headers, body))
   }
@@ -23,7 +24,7 @@ export default class FetchClient extends HttpClient {
     host: string,
     path: string,
     headers: Record<string, string> = {},
-    body: Record<string, string> = {}
+    body: HttpClientRequestBodyPayload | null = {}
   ): Promise<Response> {
     return await this.makeRequest(this.request(host, path, 'PATCH', headers, body))
   }
@@ -32,7 +33,7 @@ export default class FetchClient extends HttpClient {
     host: string,
     path: string,
     headers: Record<string, string> = {},
-    body: Record<string, string> = {}
+    body: HttpClientRequestBodyPayload | null = {}
   ): Promise<Response> {
     return await this.makeRequest(this.request(host, path, 'PUT', headers, body))
   }
@@ -54,7 +55,7 @@ export default class FetchClient extends HttpClient {
     path: string,
     method: string,
     headers: Record<string, string>,
-    body: Record<string, string> | null
+    body: HttpClientRequestBodyPayload | null = {}
   ): HttpClientRequest {
     return new HttpClientRequest(host, path, method, headers, body)
   }

--- a/src/net/HttpClientRequest.ts
+++ b/src/net/HttpClientRequest.ts
@@ -1,3 +1,8 @@
+import HttpClientRequestBody, {
+  type HttpClientRequestBodyPayload,
+  type HttpClientRequestSerializedBody
+} from './HttpClientRequestBody'
+
 interface HttpsRequestOptions {
   hostname: string
   path: string
@@ -8,38 +13,38 @@ interface HttpsRequestOptions {
 export default class HttpClientRequest {
   readonly url: URL
   readonly method: string
-  readonly headers: Record<string, string> | null
-  readonly body: Record<string, string> | null
+  readonly headers?: Record<string, string> | null
+  readonly body?: HttpClientRequestBody | null
 
   constructor (
     host: string,
     path: string,
     method: string,
     headers: Record<string, string> | null = null,
-    body: Record<string, string> | null = null
+    body: HttpClientRequestBodyPayload | null = null
   ) {
     this.url = new URL(path, host)
     this.method = method
     this.headers = headers
-    this.body = body
+    this.body = body !== null ? new HttpClientRequestBody(body) : null
   }
 
-  get stringifiedBody (): string | null {
-    return (this.body != null) ? JSON.stringify(this.body) : null
+  get serializedBody (): HttpClientRequestSerializedBody | null {
+    return this.body?.serialized
   }
 
-  toRequest (): Request {
+  public toRequest (): Request {
     return new Request(
       this.url.toString(),
       {
         method: this.method,
         headers: this.headers,
-        body: this.stringifiedBody
+        body: this.body?.serialized
       }
     )
   }
 
-  toHttpsRequestOptions (): HttpsRequestOptions {
+  public toHttpsRequestOptions (): HttpsRequestOptions {
     return {
       hostname: this.url.hostname,
       path: this.url.pathname,

--- a/src/net/HttpClientRequestBody.ts
+++ b/src/net/HttpClientRequestBody.ts
@@ -1,0 +1,19 @@
+export type HttpClientRequestBodyPayload = Record<string, string | boolean | number> | ArrayBuffer | Buffer | string
+
+export type HttpClientRequestSerializedBody = string | ArrayBuffer | Buffer
+
+export default class HttpClientRequestBody {
+  readonly body: HttpClientRequestBodyPayload
+
+  constructor (body: HttpClientRequestBodyPayload) {
+    this.body = body
+  }
+
+  public get serialized (): HttpClientRequestSerializedBody {
+    if (typeof this.body === 'object') {
+      return JSON.stringify(this.body)
+    } else {
+      return this.body
+    }
+  }
+}

--- a/src/net/NodeClient.ts
+++ b/src/net/NodeClient.ts
@@ -1,6 +1,7 @@
 import * as https from 'https'
 import HttpClient from './HttpClient'
 import HttpClientRequest from './HttpClientRequest'
+import { type HttpClientRequestBodyPayload } from './HttpClientRequestBody'
 
 export default class NodeClient extends HttpClient {
   public static async get (
@@ -15,7 +16,7 @@ export default class NodeClient extends HttpClient {
     host: string,
     path: string,
     headers: Record<string, string> = {},
-    body: Record<string, string> = {}
+    body: HttpClientRequestBodyPayload | null = {}
   ): Promise<Response> {
     return await this.makeRequest(this.request(host, path, 'POST', headers, body))
   }
@@ -24,7 +25,7 @@ export default class NodeClient extends HttpClient {
     host: string,
     path: string,
     headers: Record<string, string> = {},
-    body: Record<string, string> = {}
+    body: HttpClientRequestBodyPayload | null = {}
   ): Promise<Response> {
     return await this.makeRequest(this.request(host, path, 'PATCH', headers, body))
   }
@@ -33,7 +34,7 @@ export default class NodeClient extends HttpClient {
     host: string,
     path: string,
     headers: Record<string, string> = {},
-    body: Record<string, string> = {}
+    body: HttpClientRequestBodyPayload | null = {}
   ): Promise<Response> {
     return await this.makeRequest(this.request(host, path, 'PUT', headers, body))
   }
@@ -65,7 +66,7 @@ export default class NodeClient extends HttpClient {
 
       httpsRequest.on('error', (error) => { reject(error) })
 
-      if (httpClientRequest.body != null) httpsRequest.write(httpClientRequest.stringifiedBody)
+      if (httpClientRequest.body != null) httpsRequest.write(httpClientRequest.serializedBody)
 
       httpsRequest.end()
     })
@@ -76,7 +77,7 @@ export default class NodeClient extends HttpClient {
     path: string,
     method: string,
     headers: Record<string, string>,
-    body: Record<string, string> | null
+    body: HttpClientRequestBodyPayload | null = {}
   ): HttpClientRequest {
     return new HttpClientRequest(host, path, method, headers, body)
   }

--- a/test/helpers/fetchHelpers.ts
+++ b/test/helpers/fetchHelpers.ts
@@ -1,3 +1,5 @@
+import { type HttpClientRequestBodyPayload } from '../../src/net/HttpClientRequestBody'
+
 export function mockFetch (): jest.Mock {
   const mockFetch = jest.fn().mockResolvedValue(new Response())
   jest.spyOn(globalThis, 'fetch').mockImplementation(mockFetch)
@@ -20,10 +22,20 @@ export function assertRequestPayload (
   path: string,
   method: string,
   headers: Record<string, string>,
-  body: Record<string, string> | null = null
+  body: HttpClientRequestBodyPayload | null = null
 ): void {
   const url = new URL(path, host)
-  const request = new Request(url.toString(), { method, headers, body: (body != null) ? JSON.stringify(body) : null })
+
+  /**
+   * A `body` can consist of a string, a record, a `Buffer`-like variable or nothing.
+   * The `record` body is the only one which requires some serialization to be processed.
+   * This block of code assumes this fact to adapt to body to the format clients should send.
+   */
+  const serializedBody = body !== null
+    ? ((typeof body === 'object') ? JSON.stringify(body) : body)
+    : undefined
+
+  const request = new Request(url.toString(), { method, headers, body: serializedBody })
 
   expect(mock).toHaveBeenCalledWith(request)
 }

--- a/test/net/FetchClient.test.ts
+++ b/test/net/FetchClient.test.ts
@@ -33,14 +33,7 @@ describe('FetchClient', () => {
     it('performs POST request', async () => {
       const body = { title: 'foo', body: 'bar', userId: 1 }
 
-      const response = await FetchClient.post(
-        'https://jsonplaceholder.typicode.com',
-        '/posts',
-        {},
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        body
-      )
+      const response = await FetchClient.post('https://jsonplaceholder.typicode.com', '/posts', {}, body)
 
       expect(response.status).toBe(201)
     })
@@ -54,12 +47,8 @@ describe('FetchClient', () => {
       const headers = { Authorization: 'Bearer token' }
       const body: Record<string, string | number> = { title: 'foo', body: 'bar', userId: 1 }
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
       await FetchClient.post('https://jsonplaceholder.typicode.com', '/posts', headers, body)
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
       assertRequestPayload(mock, host, path, method, headers, body)
 
       restoreFetch()
@@ -96,8 +85,6 @@ describe('FetchClient', () => {
     it('performs PUT request', async () => {
       const body = { id: 1, title: 'foo', body: 'bar', userId: 1 }
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
       const response = await FetchClient.put('https://jsonplaceholder.typicode.com', '/posts/1', {}, body)
 
       expect(response.status).toBe(200)
@@ -112,12 +99,8 @@ describe('FetchClient', () => {
       const headers = { Authorization: 'Bearer token' }
       const body = { id: 1, title: 'foo', body: 'bar', userId: 1 }
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
       await FetchClient.put('https://jsonplaceholder.typicode.com', '/posts/1', headers, body)
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
       assertRequestPayload(mock, host, path, method, headers, body)
 
       restoreFetch()

--- a/test/net/NodeClient.test.ts
+++ b/test/net/NodeClient.test.ts
@@ -36,14 +36,7 @@ describe('NodeClient', () => {
     it('performs POST request', async () => {
       const body: Record<string, string | number> = { title: 'foo', body: 'bar', userId: 1 }
 
-      const response = await NodeClient.post(
-        'https://jsonplaceholder.typicode.com',
-        '/posts',
-        {},
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        body
-      )
+      const response = await NodeClient.post('https://jsonplaceholder.typicode.com', '/posts', {}, body)
 
       expect(response.status).toBe(201)
     })
@@ -95,8 +88,6 @@ describe('NodeClient', () => {
     it('performs PUT request', async () => {
       const body = { id: 1, title: 'foo', body: 'bar', userId: 1 }
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
       const response = await NodeClient.put('https://jsonplaceholder.typicode.com', '/posts/1', {}, body)
 
       expect(response.status).toBe(200)

--- a/test/records/Device .connect given valid pair token, updates Device with new session token/recordings_613089741/recording.har
+++ b/test/records/Device .connect given valid pair token, updates Device with new session token/recordings_613089741/recording.har
@@ -40,7 +40,7 @@
           "content": {
             "mimeType": "text/plain; charset=utf-8",
             "size": 957,
-            "text": "eyJhbGciOiJIUzI1NiIsImtpZCI6IjEiLCJ0eXAiOiJKV1QifQ.eyJhdXRoMC1wcm9maWxlIjp7IlVzZXJJRCI6ImF1dGgwfDVlZmMyODdmYzQ4ODAxMDAxMzQ0ZjkyMyIsIklzU29jaWFsIjpmYWxzZSwiQ29ubmVjdGlvbiI6IlVzZXJuYW1lLVBhc3N3b3JkLUF1dGhlbnRpY2F0aW9uIiwiTmFtZSI6InBhc2N1MjE2QGdtYWlsLmNvbSIsIk5pY2tuYW1lIjoicGFzY3UyMTYiLCJHaXZlbk5hbWUiOiIiLCJGYW1pbHlOYW1lIjoiIiwiRW1haWwiOiJwYXNjdTIxNkBnbWFpbC5jb20iLCJFbWFpbFZlcmlmaWVkIjp0cnVlLCJDcmVhdGVkQXQiOiIyMDIwLTA3LTAxVDA2OjA5OjAzLjk0M1oiLCJVcGRhdGVkQXQiOiIyMDI0LTAyLTI2VDA3OjMzOjEzLjI4NloifSwiYmV0YSI6dHJ1ZSwiZGV2aWNlLWRlc2MiOiJicm93c2VyLWNocm9tZSIsImRldmljZS1pZCI6IjAyY2U3OTUwLTBiMWUtNDAzOS05NWE3LWUwOThlMTBjMzNmYSIsImV4cCI6MTcwOTAyODY2NiwiaWF0IjoxNzA5MDE3ODY2LCJpc3MiOiJyTSBXZWJBcHAiLCJqdGkiOiJjazB0K29CWnhXTT0iLCJsZXZlbCI6ImNvbm5lY3QiLCJuYmYiOjE3MDkwMTc4NjYsInNjb3BlcyI6InN5bmM6dG9ydG9pc2Ugc2NyZWVuc2hhcmUgZG9jZWRpdCBpbnRnciBtYWlsOi0xIGh3Y21haWw6LTEiLCJzdWIiOiJhdXRoMHw1ZWZjMjg3ZmM0ODgwMTAwMTM0NGY5MjMifQ.DLB0lT7ONr8Du3JZrKPjHsyJ1GrjSb2gVL4Ig6LJ624"
+            "text": "eyJhbGciOiJIUzI1NiIsImtpZCI6IjEiLCJ0eXAiOiJKV1QifQ.eyJhdXRoMC1wcm9maWxlIjp7IlVzZXJJRCI6ImF1dGgwfDVlZmMyODdmYzQ4ODAxMDAxMzQ0ZjkyMyIsIklzU29jaWFsIjpmYWxzZSwiQ29ubmVjdGlvbiI6IlVzZXJuYW1lLVBhc3N3b3JkLUF1dGhlbnRpY2F0aW9uIiwiTmFtZSI6InBhc2N1MjE2QGdtYWlsLmNvbSIsIk5pY2tuYW1lIjoicGFzY3UyMTYiLCJHaXZlbk5hbWUiOiIiLCJGYW1pbHlOYW1lIjoiIiwiRW1haWwiOiJwYXNjdTIxNkBnbWFpbC5jb20iLCJFbWFpbFZlcmlmaWVkIjp0cnVlLCJDcmVhdGVkQXQiOiIyMDIwLTA3LTAxVDA2OjA5OjAzLjk0M1oiLCJVcGRhdGVkQXQiOiIyMDI0LTAzLTA2VDA3OjU3OjM4LjMzNFoifSwiYmV0YSI6dHJ1ZSwiZGV2aWNlLWRlc2MiOiJicm93c2VyLWNocm9tZSIsImRldmljZS1pZCI6IjAyY2U3OTUwLTBiMWUtNDAzOS05NWE3LWUwOThlMTBjMzNmYSIsImV4cCI6MTcwOTgyOTA5NCwiaWF0IjoxNzA5ODE4Mjk0LCJpc3MiOiJyTSBXZWJBcHAiLCJqdGkiOiJjazB0eVZjUjl5dz0iLCJsZXZlbCI6ImNvbm5lY3QiLCJuYmYiOjE3MDk4MTgyOTQsInNjb3BlcyI6ImludGdyIGh3Y21haWw6LTEgZG9jZWRpdCBtYWlsOi0xIHNjcmVlbnNoYXJlIHN5bmM6dG9ydG9pc2UiLCJzdWIiOiJhdXRoMHw1ZWZjMjg3ZmM0ODgwMTAwMTM0NGY5MjMifQ.EBSkEZNvr2UufS2Ctpgaifdu7ysDJRWpayyjxlx1ISs"
           },
           "cookies": [],
           "headers": [
@@ -66,11 +66,11 @@
             },
             {
               "name": "x-cloud-trace-context",
-              "value": "f17a46ed6b1a81eda923ea7676bd8bd0"
+              "value": "0bba4489eacdd48970f8ef2c76c6eb79"
             },
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:11:06 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:34 GMT"
             },
             {
               "name": "server",
@@ -95,8 +95,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-27T07:11:02.914Z",
-        "time": 4063,
+        "startedDateTime": "2024-03-07T13:31:34.688Z",
+        "time": 254,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -104,7 +104,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 4063
+          "wait": 254
         }
       }
     ],

--- a/test/records/FetchClient .delete performs DELETE request/recordings_613089741/recording.har
+++ b/test/records/FetchClient .delete performs DELETE request/recordings_613089741/recording.har
@@ -52,7 +52,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:04:44 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:37 GMT"
             },
             {
               "name": "content-length",
@@ -64,11 +64,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017484&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=LRl9T7vO90FvDUiNDxiYFSoIGe2f1GXQHXrDXXR6o8Y%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818297&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=814IgVlVflwxdvSKo3IF4Ig0ClxLz3jF2UTg20xiCss%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017484&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=LRl9T7vO90FvDUiNDxiYFSoIGe2f1GXQHXrDXXR6o8Y%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818297&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=814IgVlVflwxdvSKo3IF4Ig0ClxLz3jF2UTg20xiCss%3D"
             },
             {
               "name": "nel",
@@ -84,11 +84,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "994"
+              "value": "990"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017488"
+              "value": "1709818333"
             },
             {
               "name": "access-control-allow-origin",
@@ -120,7 +120,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be934fa86d2fa6-MAD"
+              "value": "860af26319342c59-FRA"
             },
             {
               "name": "alt-svc",
@@ -133,8 +133,8 @@
           "status": 204,
           "statusText": "No Content"
         },
-        "startedDateTime": "2024-02-27T07:04:42.677Z",
-        "time": 2138,
+        "startedDateTime": "2024-03-07T13:31:36.697Z",
+        "time": 376,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -142,7 +142,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2138
+          "wait": 376
         }
       },
       {
@@ -199,7 +199,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:04:45 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:37 GMT"
             },
             {
               "name": "content-type",
@@ -215,11 +215,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017485&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=pLCUdP902SLN1zbY5ZvnxV2ula1Fp87Ve2l7Nf56NTw%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818297&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=814IgVlVflwxdvSKo3IF4Ig0ClxLz3jF2UTg20xiCss%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017485&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=pLCUdP902SLN1zbY5ZvnxV2ula1Fp87Ve2l7Nf56NTw%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818297&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=814IgVlVflwxdvSKo3IF4Ig0ClxLz3jF2UTg20xiCss%3D"
             },
             {
               "name": "nel",
@@ -235,11 +235,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "993"
+              "value": "989"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017488"
+              "value": "1709818333"
             },
             {
               "name": "access-control-allow-origin",
@@ -287,7 +287,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be935069462fa6-MAD"
+              "value": "860af2653beb2c59-FRA"
             },
             {
               "name": "alt-svc",
@@ -300,8 +300,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-27T07:04:44.819Z",
-        "time": 290,
+        "startedDateTime": "2024-03-07T13:31:37.078Z",
+        "time": 326,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -309,7 +309,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 290
+          "wait": 326
         }
       }
     ],

--- a/test/records/FetchClient .get performs GET request/recordings_613089741/recording.har
+++ b/test/records/FetchClient .get performs GET request/recordings_613089741/recording.har
@@ -62,7 +62,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:04:37 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:35 GMT"
             },
             {
               "name": "content-type",
@@ -78,11 +78,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1703873087&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=MgkKNaBl250KsGaeAOAWLWi%2BWkFtoV%2F7W2V5jpuXw6E%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709630817&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=2vA99MrJDGVJ0Ib9XC7O8MaNnFN%2F9s%2Bt69cxZ%2BvclcY%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1703873087&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=MgkKNaBl250KsGaeAOAWLWi%2BWkFtoV%2F7W2V5jpuXw6E%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709630817&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=2vA99MrJDGVJ0Ib9XC7O8MaNnFN%2F9s%2Bt69cxZ%2BvclcY%3D"
             },
             {
               "name": "nel",
@@ -102,7 +102,7 @@
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1703873136"
+              "value": "1709630855"
             },
             {
               "name": "access-control-allow-origin",
@@ -146,7 +146,7 @@
             },
             {
               "name": "age",
-              "value": "3607"
+              "value": "26557"
             },
             {
               "name": "server",
@@ -154,7 +154,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be9323b8e56641-MAD"
+              "value": "860af258dd619b3f-FRA"
             },
             {
               "name": "content-encoding",
@@ -165,14 +165,14 @@
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1166,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-27T07:04:34.011Z",
-        "time": 3705,
+        "startedDateTime": "2024-03-07T13:31:34.968Z",
+        "time": 165,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -180,7 +180,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 3705
+          "wait": 165
         }
       }
     ],

--- a/test/records/FetchClient .patch performs PATCH request/recordings_613089741/recording.har
+++ b/test/records/FetchClient .patch performs PATCH request/recordings_613089741/recording.har
@@ -52,7 +52,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:04:42 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:35 GMT"
             },
             {
               "name": "content-length",
@@ -64,11 +64,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017481&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=4gGMFx9RGtDQKb8MKGBB6pmACSPnCvHjbcv5DYTn%2Frc%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017481&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=4gGMFx9RGtDQKb8MKGBB6pmACSPnCvHjbcv5DYTn%2Frc%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D"
             },
             {
               "name": "nel",
@@ -84,11 +84,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "998"
+              "value": "995"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017488"
+              "value": "1709818333"
             },
             {
               "name": "access-control-allow-origin",
@@ -120,21 +120,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be933d2a4e2f97-MAD"
+              "value": "860af25c6ebe4d3d-FRA"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1011,
+          "headersSize": 1023,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 204,
           "statusText": "No Content"
         },
-        "startedDateTime": "2024-02-27T07:04:40.977Z",
-        "time": 1044,
+        "startedDateTime": "2024-03-07T13:31:35.544Z",
+        "time": 272,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -142,7 +142,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1044
+          "wait": 272
         }
       },
       {
@@ -213,7 +213,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:04:42 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:36 GMT"
             },
             {
               "name": "content-type",
@@ -229,11 +229,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017482&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=CQovzpx%2FZ0iDAatLfa%2Bb7%2FQglthSVjq8yE9o%2B0V4YVo%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017482&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=CQovzpx%2FZ0iDAatLfa%2Bb7%2FQglthSVjq8yE9o%2B0V4YVo%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D"
             },
             {
               "name": "nel",
@@ -249,11 +249,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "997"
+              "value": "993"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017488"
+              "value": "1709818333"
             },
             {
               "name": "access-control-allow-origin",
@@ -301,7 +301,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be933eec462f97-MAD"
+              "value": "860af25d683d4d3d-FRA"
             },
             {
               "name": "content-encoding",
@@ -318,8 +318,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-27T07:04:42.025Z",
-        "time": 114,
+        "startedDateTime": "2024-03-07T13:31:35.823Z",
+        "time": 140,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -327,7 +327,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 114
+          "wait": 140
         }
       }
     ],

--- a/test/records/FetchClient .post performs POST request/recordings_613089741/recording.har
+++ b/test/records/FetchClient .post performs POST request/recordings_613089741/recording.har
@@ -74,7 +74,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:04:40 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:35 GMT"
             },
             {
               "name": "content-type",
@@ -90,11 +90,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017480&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=RAJY%2FDha%2BVCdPw6asAU64FW04m2IOskV8CK4n2mXyRQ%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017480&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=RAJY%2FDha%2BVCdPw6asAU64FW04m2IOskV8CK4n2mXyRQ%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D"
             },
             {
               "name": "nel",
@@ -110,11 +110,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "999"
+              "value": "997"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017488"
+              "value": "1709818333"
             },
             {
               "name": "access-control-allow-origin",
@@ -170,21 +170,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be933698915e14-MAD"
+              "value": "860af2596e289951-FRA"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1239,
+          "headersSize": 1247,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "https://jsonplaceholder.typicode.com/posts/101",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-02-27T07:04:37.743Z",
-        "time": 3218,
+        "startedDateTime": "2024-03-07T13:31:35.151Z",
+        "time": 373,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -192,7 +192,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 3218
+          "wait": 373
         }
       }
     ],

--- a/test/records/FetchClient .put performs PUT request/recordings_613089741/recording.har
+++ b/test/records/FetchClient .put performs PUT request/recordings_613089741/recording.har
@@ -52,7 +52,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:04:42 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:36 GMT"
             },
             {
               "name": "content-length",
@@ -64,11 +64,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017482&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=CQovzpx%2FZ0iDAatLfa%2Bb7%2FQglthSVjq8yE9o%2B0V4YVo%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818296&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=j%2FceUhsTVqDy8B%2Fzyy5xyQq4Tk7DyXvaMi9zOxpbVNc%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017482&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=CQovzpx%2FZ0iDAatLfa%2Bb7%2FQglthSVjq8yE9o%2B0V4YVo%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818296&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=j%2FceUhsTVqDy8B%2Fzyy5xyQq4Tk7DyXvaMi9zOxpbVNc%3D"
             },
             {
               "name": "nel",
@@ -84,11 +84,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "996"
+              "value": "992"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017488"
+              "value": "1709818333"
             },
             {
               "name": "access-control-allow-origin",
@@ -120,21 +120,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be934038332faf-MAD"
+              "value": "860af25e9c459a2a-FRA"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1023,
+          "headersSize": 1015,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 204,
           "statusText": "No Content"
         },
-        "startedDateTime": "2024-02-27T07:04:42.149Z",
-        "time": 198,
+        "startedDateTime": "2024-03-07T13:31:35.974Z",
+        "time": 372,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -142,7 +142,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 198
+          "wait": 372
         }
       },
       {
@@ -212,7 +212,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:04:42 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:36 GMT"
             },
             {
               "name": "content-type",
@@ -228,11 +228,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017482&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=CQovzpx%2FZ0iDAatLfa%2Bb7%2FQglthSVjq8yE9o%2B0V4YVo%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818296&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=j%2FceUhsTVqDy8B%2Fzyy5xyQq4Tk7DyXvaMi9zOxpbVNc%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017482&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=CQovzpx%2FZ0iDAatLfa%2Bb7%2FQglthSVjq8yE9o%2B0V4YVo%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818296&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=j%2FceUhsTVqDy8B%2Fzyy5xyQq4Tk7DyXvaMi9zOxpbVNc%3D"
             },
             {
               "name": "nel",
@@ -248,11 +248,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "995"
+              "value": "991"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017488"
+              "value": "1709818333"
             },
             {
               "name": "access-control-allow-origin",
@@ -300,21 +300,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be9340f8ed2faf-MAD"
+              "value": "860af260ade29a2a-FRA"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1124,
+          "headersSize": 1116,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-27T07:04:42.351Z",
-        "time": 315,
+        "startedDateTime": "2024-03-07T13:31:36.352Z",
+        "time": 325,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -322,7 +322,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 315
+          "wait": 325
         }
       }
     ],

--- a/test/records/NodeClient .delete performs DELETE request/recordings_613089741/recording.har
+++ b/test/records/NodeClient .delete performs DELETE request/recordings_613089741/recording.har
@@ -37,7 +37,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:05:30 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:35 GMT"
             },
             {
               "name": "content-type",
@@ -53,11 +53,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017530&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=AsKZJ0%2Bb2Frdw%2BjB8bUGU97PObhP00F3i1R4cu786PI%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017530&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=AsKZJ0%2Bb2Frdw%2BjB8bUGU97PObhP00F3i1R4cu786PI%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D"
             },
             {
               "name": "nel",
@@ -73,11 +73,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "996"
+              "value": "994"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017548"
+              "value": "1709818333"
             },
             {
               "name": "vary",
@@ -121,21 +121,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be946dd8db2f92-MAD"
+              "value": "860af25d1acf3aa2-FRA"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1068,
+          "headersSize": 1076,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-27T07:05:30.500Z",
-        "time": 102,
+        "startedDateTime": "2024-03-07T13:31:35.749Z",
+        "time": 171,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -143,7 +143,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 102
+          "wait": 171
         }
       }
     ],

--- a/test/records/NodeClient .get performs GET request/recordings_613089741/recording.har
+++ b/test/records/NodeClient .get performs GET request/recordings_613089741/recording.har
@@ -37,7 +37,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:05:29 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:34 GMT"
             },
             {
               "name": "content-type",
@@ -53,11 +53,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1708477539&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=aS7QFMVgMg1ixy638HFkL8ggyNzlrdzC5CQUFVbWJk0%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1703040337&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=PpV7Mb2M6iB1L2Kb5c3ZqYvkU5K6Sa%2BXnFS2T2JvnyE%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1708477539&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=aS7QFMVgMg1ixy638HFkL8ggyNzlrdzC5CQUFVbWJk0%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1703040337&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=PpV7Mb2M6iB1L2Kb5c3ZqYvkU5K6Sa%2BXnFS2T2JvnyE%3D"
             },
             {
               "name": "nel",
@@ -77,7 +77,7 @@
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1708477541"
+              "value": "1703040393"
             },
             {
               "name": "vary",
@@ -117,7 +117,7 @@
             },
             {
               "name": "age",
-              "value": "12281"
+              "value": "9065"
             },
             {
               "name": "accept-ranges",
@@ -129,21 +129,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be946a7ca52f92-MAD"
+              "value": "860af2573a1c3aa2-FRA"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1097,
+          "headersSize": 1100,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-27T07:05:29.892Z",
-        "time": 85,
+        "startedDateTime": "2024-03-07T13:31:34.680Z",
+        "time": 190,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -151,7 +151,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 85
+          "wait": 190
         }
       }
     ],

--- a/test/records/NodeClient .patch performs PATCH request/recordings_613089741/recording.har
+++ b/test/records/NodeClient .patch performs PATCH request/recordings_613089741/recording.har
@@ -42,7 +42,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:05:30 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:35 GMT"
             },
             {
               "name": "content-type",
@@ -58,11 +58,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017530&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=AsKZJ0%2Bb2Frdw%2BjB8bUGU97PObhP00F3i1R4cu786PI%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017530&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=AsKZJ0%2Bb2Frdw%2BjB8bUGU97PObhP00F3i1R4cu786PI%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D"
             },
             {
               "name": "nel",
@@ -82,7 +82,7 @@
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017548"
+              "value": "1709818333"
             },
             {
               "name": "vary",
@@ -126,21 +126,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be946b5dd92f92-MAD"
+              "value": "860af259bdac3aa2-FRA"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1072,
+          "headersSize": 1080,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-27T07:05:30.101Z",
-        "time": 101,
+        "startedDateTime": "2024-03-07T13:31:35.239Z",
+        "time": 159,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,7 +148,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 101
+          "wait": 159
         }
       }
     ],

--- a/test/records/NodeClient .post performs POST request/recordings_613089741/recording.har
+++ b/test/records/NodeClient .post performs POST request/recordings_613089741/recording.har
@@ -42,7 +42,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:05:30 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:35 GMT"
             },
             {
               "name": "content-type",
@@ -58,11 +58,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017530&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=AsKZJ0%2Bb2Frdw%2BjB8bUGU97PObhP00F3i1R4cu786PI%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017530&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=AsKZJ0%2Bb2Frdw%2BjB8bUGU97PObhP00F3i1R4cu786PI%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D"
             },
             {
               "name": "nel",
@@ -82,7 +82,7 @@
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017548"
+              "value": "1709818333"
             },
             {
               "name": "vary",
@@ -134,21 +134,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be946aace62f92-MAD"
+              "value": "860af257aaaa3aa2-FRA"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1192,
+          "headersSize": 1200,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "https://jsonplaceholder.typicode.com/posts/101",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-02-27T07:05:29.988Z",
-        "time": 104,
+        "startedDateTime": "2024-03-07T13:31:34.880Z",
+        "time": 351,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -156,7 +156,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 104
+          "wait": 351
         }
       }
     ],

--- a/test/records/NodeClient .put performs PUT request/recordings_613089741/recording.har
+++ b/test/records/NodeClient .put performs PUT request/recordings_613089741/recording.har
@@ -42,7 +42,7 @@
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 27 Feb 2024 07:05:30 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:35 GMT"
             },
             {
               "name": "content-type",
@@ -58,11 +58,11 @@
             },
             {
               "name": "report-to",
-              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709017530&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=AsKZJ0%2Bb2Frdw%2BjB8bUGU97PObhP00F3i1R4cu786PI%3D\"}]}"
+              "value": "{\"group\":\"heroku-nel\",\"max_age\":3600,\"endpoints\":[{\"url\":\"https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D\"}]}"
             },
             {
               "name": "reporting-endpoints",
-              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709017530&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=AsKZJ0%2Bb2Frdw%2BjB8bUGU97PObhP00F3i1R4cu786PI%3D"
+              "value": "heroku-nel=https://nel.heroku.com/reports?ts=1709818295&sid=e11707d5-02a7-43ef-b45e-2cf4d2036f7d&s=XI3MDTB%2FV5zutioUiZgcZ5W%2BCFCpq8hkpThsogn%2Ff%2FI%3D"
             },
             {
               "name": "nel",
@@ -78,11 +78,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "997"
+              "value": "996"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "1709017548"
+              "value": "1709818333"
             },
             {
               "name": "vary",
@@ -126,21 +126,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "85be946c0e9d2f92-MAD"
+              "value": "860af25acf8f3aa2-FRA"
             },
             {
               "name": "alt-svc",
               "value": "h3=\":443\"; ma=86400"
             }
           ],
-          "headersSize": 1069,
+          "headersSize": 1077,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-27T07:05:30.211Z",
-        "time": 273,
+        "startedDateTime": "2024-03-07T13:31:35.409Z",
+        "time": 327,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,7 +148,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 273
+          "wait": 327
         }
       }
     ],

--- a/test/records/ServiceDiscovery .discoverStorageHost if Device is connected, updates service discovery with storage host/recordings_613089741/recording.har
+++ b/test/records/ServiceDiscovery .discoverStorageHost if Device is connected, updates service discovery with storage host/recordings_613089741/recording.har
@@ -40,7 +40,7 @@
           "content": {
             "mimeType": "text/plain; charset=utf-8",
             "size": 957,
-            "text": "eyJhbGciOiJIUzI1NiIsImtpZCI6IjEiLCJ0eXAiOiJKV1QifQ.eyJhdXRoMC1wcm9maWxlIjp7IlVzZXJJRCI6ImF1dGgwfDVlZmMyODdmYzQ4ODAxMDAxMzQ0ZjkyMyIsIklzU29jaWFsIjpmYWxzZSwiQ29ubmVjdGlvbiI6IlVzZXJuYW1lLVBhc3N3b3JkLUF1dGhlbnRpY2F0aW9uIiwiTmFtZSI6InBhc2N1MjE2QGdtYWlsLmNvbSIsIk5pY2tuYW1lIjoicGFzY3UyMTYiLCJHaXZlbk5hbWUiOiIiLCJGYW1pbHlOYW1lIjoiIiwiRW1haWwiOiJwYXNjdTIxNkBnbWFpbC5jb20iLCJFbWFpbFZlcmlmaWVkIjp0cnVlLCJDcmVhdGVkQXQiOiIyMDIwLTA3LTAxVDA2OjA5OjAzLjk0M1oiLCJVcGRhdGVkQXQiOiIyMDI0LTAyLTI2VDA3OjMzOjEzLjI4NloifSwiYmV0YSI6dHJ1ZSwiZGV2aWNlLWRlc2MiOiJicm93c2VyLWNocm9tZSIsImRldmljZS1pZCI6IjAyY2U3OTUwLTBiMWUtNDAzOS05NWE3LWUwOThlMTBjMzNmYSIsImV4cCI6MTcwOTExNjE4MSwiaWF0IjoxNzA5MTA1MzgxLCJpc3MiOiJyTSBXZWJBcHAiLCJqdGkiOiJjazB0aDVZT2R0Yz0iLCJsZXZlbCI6ImNvbm5lY3QiLCJuYmYiOjE3MDkxMDUzODEsInNjb3BlcyI6ImRvY2VkaXQgc3luYzp0b3J0b2lzZSBzY3JlZW5zaGFyZSBod2NtYWlsOi0xIGludGdyIG1haWw6LTEiLCJzdWIiOiJhdXRoMHw1ZWZjMjg3ZmM0ODgwMTAwMTM0NGY5MjMifQ.pnJRgBMxKw_pSM1F5H8iFAXsIuZ_5Fxg5SQEWjLLi2c"
+            "text": "eyJhbGciOiJIUzI1NiIsImtpZCI6IjEiLCJ0eXAiOiJKV1QifQ.eyJhdXRoMC1wcm9maWxlIjp7IlVzZXJJRCI6ImF1dGgwfDVlZmMyODdmYzQ4ODAxMDAxMzQ0ZjkyMyIsIklzU29jaWFsIjpmYWxzZSwiQ29ubmVjdGlvbiI6IlVzZXJuYW1lLVBhc3N3b3JkLUF1dGhlbnRpY2F0aW9uIiwiTmFtZSI6InBhc2N1MjE2QGdtYWlsLmNvbSIsIk5pY2tuYW1lIjoicGFzY3UyMTYiLCJHaXZlbk5hbWUiOiIiLCJGYW1pbHlOYW1lIjoiIiwiRW1haWwiOiJwYXNjdTIxNkBnbWFpbC5jb20iLCJFbWFpbFZlcmlmaWVkIjp0cnVlLCJDcmVhdGVkQXQiOiIyMDIwLTA3LTAxVDA2OjA5OjAzLjk0M1oiLCJVcGRhdGVkQXQiOiIyMDI0LTAzLTA2VDA3OjU3OjM4LjMzNFoifSwiYmV0YSI6dHJ1ZSwiZGV2aWNlLWRlc2MiOiJicm93c2VyLWNocm9tZSIsImRldmljZS1pZCI6IjAyY2U3OTUwLTBiMWUtNDAzOS05NWE3LWUwOThlMTBjMzNmYSIsImV4cCI6MTcwOTgyOTA5NSwiaWF0IjoxNzA5ODE4Mjk1LCJpc3MiOiJyTSBXZWJBcHAiLCJqdGkiOiJjazB0NFBjYkY0WT0iLCJsZXZlbCI6ImNvbm5lY3QiLCJuYmYiOjE3MDk4MTgyOTUsInNjb3BlcyI6ImRvY2VkaXQgaW50Z3Igc3luYzp0b3J0b2lzZSBtYWlsOi0xIGh3Y21haWw6LTEgc2NyZWVuc2hhcmUiLCJzdWIiOiJhdXRoMHw1ZWZjMjg3ZmM0ODgwMTAwMTM0NGY5MjMifQ.9ouvt5RmQD_ch-ps1tvqUUzcWt9X_RC6j7Q-G8OPpOw"
           },
           "cookies": [],
           "headers": [
@@ -54,11 +54,11 @@
             },
             {
               "name": "x-ratelimit-remaining",
-              "value": "4"
+              "value": "3"
             },
             {
               "name": "x-ratelimit-reset",
-              "value": "12"
+              "value": "24"
             },
             {
               "name": "content-type",
@@ -66,11 +66,11 @@
             },
             {
               "name": "x-cloud-trace-context",
-              "value": "50615a1fdd5f278b520715ea7b7c4900"
+              "value": "009ba96142e2f56011c71903170d2f95"
             },
             {
               "name": "date",
-              "value": "Wed, 28 Feb 2024 07:29:41 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:35 GMT"
             },
             {
               "name": "server",
@@ -95,8 +95,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-28T07:29:40.262Z",
-        "time": 1070,
+        "startedDateTime": "2024-03-07T13:31:34.915Z",
+        "time": 181,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -104,11 +104,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1070
+          "wait": 181
         }
       },
       {
-        "_id": "7cd5b286fa27080e242dd76ffcfd42e6",
+        "_id": "9912ff6f59ca059dedf4d2b8d27b1f85",
         "_order": 0,
         "cache": {},
         "request": {
@@ -117,7 +117,7 @@
           "headers": [
             {
               "name": "authorization",
-              "value": "Bearer eyJhbGciOiJIUzI1NiIsImtpZCI6IjEiLCJ0eXAiOiJKV1QifQ.eyJhdXRoMC1wcm9maWxlIjp7IlVzZXJJRCI6ImF1dGgwfDVlZmMyODdmYzQ4ODAxMDAxMzQ0ZjkyMyIsIklzU29jaWFsIjpmYWxzZSwiQ29ubmVjdGlvbiI6IlVzZXJuYW1lLVBhc3N3b3JkLUF1dGhlbnRpY2F0aW9uIiwiTmFtZSI6InBhc2N1MjE2QGdtYWlsLmNvbSIsIk5pY2tuYW1lIjoicGFzY3UyMTYiLCJHaXZlbk5hbWUiOiIiLCJGYW1pbHlOYW1lIjoiIiwiRW1haWwiOiJwYXNjdTIxNkBnbWFpbC5jb20iLCJFbWFpbFZlcmlmaWVkIjp0cnVlLCJDcmVhdGVkQXQiOiIyMDIwLTA3LTAxVDA2OjA5OjAzLjk0M1oiLCJVcGRhdGVkQXQiOiIyMDI0LTAyLTI2VDA3OjMzOjEzLjI4NloifSwiYmV0YSI6dHJ1ZSwiZGV2aWNlLWRlc2MiOiJicm93c2VyLWNocm9tZSIsImRldmljZS1pZCI6IjAyY2U3OTUwLTBiMWUtNDAzOS05NWE3LWUwOThlMTBjMzNmYSIsImV4cCI6MTcwOTExNjE4MSwiaWF0IjoxNzA5MTA1MzgxLCJpc3MiOiJyTSBXZWJBcHAiLCJqdGkiOiJjazB0aDVZT2R0Yz0iLCJsZXZlbCI6ImNvbm5lY3QiLCJuYmYiOjE3MDkxMDUzODEsInNjb3BlcyI6ImRvY2VkaXQgc3luYzp0b3J0b2lzZSBzY3JlZW5zaGFyZSBod2NtYWlsOi0xIGludGdyIG1haWw6LTEiLCJzdWIiOiJhdXRoMHw1ZWZjMjg3ZmM0ODgwMTAwMTM0NGY5MjMifQ.pnJRgBMxKw_pSM1F5H8iFAXsIuZ_5Fxg5SQEWjLLi2c"
+              "value": "Bearer eyJhbGciOiJIUzI1NiIsImtpZCI6IjEiLCJ0eXAiOiJKV1QifQ.eyJhdXRoMC1wcm9maWxlIjp7IlVzZXJJRCI6ImF1dGgwfDVlZmMyODdmYzQ4ODAxMDAxMzQ0ZjkyMyIsIklzU29jaWFsIjpmYWxzZSwiQ29ubmVjdGlvbiI6IlVzZXJuYW1lLVBhc3N3b3JkLUF1dGhlbnRpY2F0aW9uIiwiTmFtZSI6InBhc2N1MjE2QGdtYWlsLmNvbSIsIk5pY2tuYW1lIjoicGFzY3UyMTYiLCJHaXZlbk5hbWUiOiIiLCJGYW1pbHlOYW1lIjoiIiwiRW1haWwiOiJwYXNjdTIxNkBnbWFpbC5jb20iLCJFbWFpbFZlcmlmaWVkIjp0cnVlLCJDcmVhdGVkQXQiOiIyMDIwLTA3LTAxVDA2OjA5OjAzLjk0M1oiLCJVcGRhdGVkQXQiOiIyMDI0LTAzLTA2VDA3OjU3OjM4LjMzNFoifSwiYmV0YSI6dHJ1ZSwiZGV2aWNlLWRlc2MiOiJicm93c2VyLWNocm9tZSIsImRldmljZS1pZCI6IjAyY2U3OTUwLTBiMWUtNDAzOS05NWE3LWUwOThlMTBjMzNmYSIsImV4cCI6MTcwOTgyOTA5NSwiaWF0IjoxNzA5ODE4Mjk1LCJpc3MiOiJyTSBXZWJBcHAiLCJqdGkiOiJjazB0NFBjYkY0WT0iLCJsZXZlbCI6ImNvbm5lY3QiLCJuYmYiOjE3MDk4MTgyOTUsInNjb3BlcyI6ImRvY2VkaXQgaW50Z3Igc3luYzp0b3J0b2lzZSBtYWlsOi0xIGh3Y21haWw6LTEgc2NyZWVuc2hhcmUiLCJzdWIiOiJhdXRoMHw1ZWZjMjg3ZmM0ODgwMTAwMTM0NGY5MjMifQ.9ouvt5RmQD_ch-ps1tvqUUzcWt9X_RC6j7Q-G8OPpOw"
             },
             {
               "name": "host",
@@ -149,11 +149,11 @@
             },
             {
               "name": "x-cloud-trace-context",
-              "value": "fe9bd23080dab5998189aa9c60a7e43d;o=1"
+              "value": "f95d69cba5976d4eebd53549a7bc4901"
             },
             {
               "name": "date",
-              "value": "Wed, 28 Feb 2024 07:29:41 GMT"
+              "value": "Thu, 07 Mar 2024 13:31:35 GMT"
             },
             {
               "name": "server",
@@ -168,14 +168,14 @@
               "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
             }
           ],
-          "headersSize": 257,
+          "headersSize": 253,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-02-28T07:29:41.348Z",
-        "time": 110,
+        "startedDateTime": "2024-03-07T13:31:35.103Z",
+        "time": 139,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -183,7 +183,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 110
+          "wait": 139
         }
       }
     ],


### PR DESCRIPTION
We initially assumed a Body could only be a `Record` or a `string`. This is wrong; other possible formats exist, such as `Buffer` or `Array` buffer.

On top of that, certain kinds of `body` require some serialization to be delivered in requests.

This commit defines a new `Body` class that handles different kinds of body payloads, pre-processing them according to the client's needs and providing a simple interface for providing the serialized payloads. Now, our HTTP clients use this object to send requests with body.