### PR TITLE
chore: Add logic for merging to `HttpContext`

### DIFF
--- a/src/net/HttpClient.ts
+++ b/src/net/HttpClient.ts
@@ -1,4 +1,4 @@
-import type HttpClientContext from './HttpClientContext'
+import HttpClientContext from './HttpClientContext'
 
 /**
  * HTTP Client abstract class
@@ -71,7 +71,7 @@ export default abstract class HttpClient {
   readonly context: HttpClientContext
 
   constructor (host: string, headers: Record<string, string> = {}) {
-    this.context = { host, headers }
+    this.context = new HttpClientContext(host, headers)
   }
 
   public async get (
@@ -87,8 +87,10 @@ export default abstract class HttpClient {
     body: Record<string, string> = {},
     context: HttpClientContext = this.context
   ): Promise<Response> {
+    const requestContext: HttpClientContext = this.context.merge(context)
+
     return await this.classReference()
-      .post(context.host ?? this.context.host, path, context.headers ?? this.context.headers, body)
+      .post(requestContext.host, path, requestContext.headers, body)
   }
 
   public async patch (
@@ -96,8 +98,10 @@ export default abstract class HttpClient {
     body: Record<string, string> = {},
     context: HttpClientContext = this.context
   ): Promise<Response> {
+    const requestContext: HttpClientContext = this.context.merge(context)
+
     return await this.classReference()
-      .patch(context.host ?? this.context.host, path, context.headers ?? this.context.headers, body)
+      .patch(requestContext.host, path, requestContext.headers, body)
   }
 
   public async put (
@@ -105,16 +109,20 @@ export default abstract class HttpClient {
     body: Record<string, string> = {},
     context: HttpClientContext = this.context
   ): Promise<Response> {
+    const requestContext: HttpClientContext = this.context.merge(context)
+
     return await this.classReference()
-      .put(context.host ?? this.context.host, path, context.headers ?? this.context.headers, body)
+      .put(requestContext.host, path, requestContext.headers, body)
   }
 
   public async delete (
     path: string,
     context: HttpClientContext = this.context
   ): Promise<Response> {
+    const requestContext: HttpClientContext = this.context.merge(context)
+
     return await this.classReference()
-      .delete(context.host ?? this.context.host, path, context.headers ?? this.context.headers)
+      .delete(requestContext.host, path, requestContext.headers)
   }
 
   /**

--- a/src/net/HttpClientContext.ts
+++ b/src/net/HttpClientContext.ts
@@ -10,7 +10,19 @@
  * @property {string} host - The host of the context. All client HTTP requests will be performed to this host.
  * @property {Headers} [headers] - The headers of the context. All client HTTP requests will be performed with these headers.
  */
-export default interface HttpClientContext {
+export default class HttpClientContext {
   readonly host?: string
   readonly headers?: Record<string, string>
+
+  constructor (host?: string, headers?: Record<string, string>) {
+    this.host = host
+    this.headers = headers
+  }
+
+  public merge (otherContext: HttpClientContext): HttpClientContext {
+    return new HttpClientContext(
+      otherContext.host ?? this.host,
+      { ...this.headers, ...otherContext.headers }
+    )
+  }
 }

--- a/test/net/HttpClient.test.ts
+++ b/test/net/HttpClient.test.ts
@@ -1,5 +1,5 @@
 import HttpClient from '../../src/net/HttpClient'
-import type HttpClientContext from '../../src/net/HttpClientContext'
+import HttpClientContext from '../../src/net/HttpClientContext'
 
 /**
  * Test HTTP client used to test the behavior of HttpClient instances
@@ -69,10 +69,7 @@ class TestHttpClient extends HttpClient {
 }
 
 describe('HttpClient', () => {
-  const context: HttpClientContext = {
-    host: 'https://jsonplaceholder.typicode.com',
-    headers: { Authorization: 'Bearer token' }
-  }
+  const context = new HttpClientContext('https://jsonplaceholder.typicode.com', { Authorization: 'Bearer token' })
 
   const httpClient: TestHttpClient = new TestHttpClient(context.host, context.headers)
 
@@ -98,10 +95,7 @@ describe('HttpClient', () => {
       'if context is specified and host & headers are specified,' +
             'performs GET request with specified host and headers',
       async () => {
-        const otherContext: HttpClientContext = {
-          host: 'other',
-          headers: { Authorization: 'Bearer otherToken' }
-        }
+        const otherContext = new HttpClientContext('other', { Authorization: 'Bearer otherToken' })
 
         const response = await httpClient.get('/todos/1', otherContext)
         const responseJson = await response.json()
@@ -141,10 +135,7 @@ describe('HttpClient', () => {
       'if context is specified and host & headers are specified,' +
             'performs POST request with specified host and headers',
       async () => {
-        const otherContext: HttpClientContext = {
-          host: 'other',
-          headers: { Authorization: 'Bearer otherToken' }
-        }
+        const otherContext = new HttpClientContext('other', { Authorization: 'Bearer otherToken' })
         const body = { title: 'foo', body: 'bar' }
 
         const response = await httpClient.post('/posts', body, otherContext)
@@ -185,10 +176,7 @@ describe('HttpClient', () => {
       'if context is specified and host & headers are specified,' +
             'performs PATCH request with specified host and headers',
       async () => {
-        const otherContext: HttpClientContext = {
-          host: 'other',
-          headers: { Authorization: 'Bearer otherToken' }
-        }
+        const otherContext = new HttpClientContext('other', { Authorization: 'Bearer otherToken' })
         const body = { title: 'foo' }
 
         const response = await httpClient.patch('/posts', body, otherContext)
@@ -229,10 +217,7 @@ describe('HttpClient', () => {
       'if context is specified and host & headers are specified,' +
             'performs PUT request with specified host and headers',
       async () => {
-        const otherContext: HttpClientContext = {
-          host: 'other',
-          headers: { Authorization: 'Bearer otherToken' }
-        }
+        const otherContext = new HttpClientContext('other', { Authorization: 'Bearer otherToken' })
         const body = { title: 'foo', body: 'bar' }
 
         const response = await httpClient.put('/posts', body, otherContext)
@@ -271,10 +256,7 @@ describe('HttpClient', () => {
       'if context is specified and host & headers are specified,' +
             'performs DELETE request with specified host and headers',
       async () => {
-        const otherContext: HttpClientContext = {
-          host: 'other',
-          headers: { Authorization: 'Bearer otherToken' }
-        }
+        const otherContext = new HttpClientContext('other', { Authorization: 'Bearer otherToken' })
 
         const response = await httpClient.delete('/todos/1', otherContext)
         const responseJson = await response.json()

--- a/test/net/HttpClientContext.test.ts
+++ b/test/net/HttpClientContext.test.ts
@@ -1,0 +1,45 @@
+import HttpClientContext from '../../src/net/HttpClientContext'
+
+describe('HttpClientContext', () => {
+  const context = new HttpClientContext('https://example.com', { Authentication: 'Bearer token' })
+
+  describe('merge', () => {
+    it('if given context has host, returns given context host', () => {
+      const otherContext = new HttpClientContext('https://other.com')
+
+      const mergedContext = context.merge(otherContext)
+
+      expect(mergedContext.host).toBe(otherContext.host)
+    })
+
+    it('if given context has no host, returns original context host', () => {
+      const otherContext = new HttpClientContext()
+
+      const mergedContext = context.merge(otherContext)
+
+      expect(mergedContext.host).toBe(context.host)
+    })
+
+    it('if given context has headers, returns context with given context headers', () => {
+      const otherContext = new HttpClientContext(null, { 'Content-Type': 'application/json' })
+
+      const mergedContext = context.merge(otherContext)
+      const expectedContextHeaders = {
+        Authentication: 'Bearer token',
+        'Content-Type': 'application/json'
+      }
+
+      expect(mergedContext.headers).toEqual(expectedContextHeaders)
+    })
+
+    it('if given context headers has header/s present in original context,' +
+             'returns context with common headers overwritten by given context', () => {
+      const otherContext = new HttpClientContext(null, { Authentication: 'Bearer new' })
+
+      const mergedContext = context.merge(otherContext)
+      const expectedContextHeaders = { Authentication: 'Bearer new' }
+
+      expect(mergedContext.headers).toEqual(expectedContextHeaders)
+    })
+  })
+})


### PR DESCRIPTION
It is very common when using HttpClient instances to specify new contexts (headers) to perform specific requests.

To better handle this logic I turned the HttpClientContext type into a class. It now presents a `merge` method which allows combining two `Contexts` into a single one.

When two `Contexts` are merge, host and header values are combined. If both context share a host or specific headers, the original values will be overwritten by the ones from the given context.