### PR TITLE
chore: `package.json` configuration for exporting library

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -1,9 +1,8 @@
-const path = require('path');
-
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
+const config = {
 	preset: 'ts-jest',
 	rootDir: '..',
 	testEnvironment: 'node',
 	setupFilesAfterEnv: ['./test/jest.setup.ts']
 }
+
+export default config

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */

--- a/config/tsup.config.ts
+++ b/config/tsup.config.ts
@@ -7,11 +7,11 @@ export const tsup: Options = {
   clean: true,                  // Clean dist folder before bundling
   dts: true,                    // Generate Typescript definition file
   format: ['cjs', 'esm'],       // Generate CJS and ESM bundles
-  minify: env === 'production',
-  bundle: env === 'production',
+  minify: true,
+  bundle: true,
   skipNodeModulesBundle: true,  // Avoid bundling npm dependencies in resulting bundle
   watch: env === 'development', // (only in development) Enable file watch
   target: 'es2020',
-  outDir: env === 'production' ? 'dist' : 'lib',
+  outDir: 'dist',
   entry: ['./src/index.ts']
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,17 @@
 {
   "name": "a-remarkable-js-sdk",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Simple project to define a JavasScript library (with TypeScript) to interact with the Remarkable API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test:setup": " npx ts-node --project ./config/tsconfig.json scripts/regenerateTestData.ts",
     "test:unit": "jest --config config/jest.config.js",


### PR DESCRIPTION
Add missing configuration options that make it possible to import packages into other projects.

You can test the package can be used by other projects via the `yarn link` and `yarn link a-remarkable-js-sdk` commands.