### PR TITLE
refactor: FileBuffer.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Device, type DeviceDescription, Session } from './authentication'
 import {
   Document,
-  FileNoUploadedError,
+  FileNotUploadedError,
   FileBuffer,
   UnsupportedFileExtensionError,
   FileBufferType,
@@ -16,7 +16,7 @@ import ServiceManager from './serviceDiscovery/ServiceManager'
 export {
   Device, type DeviceDescription, Session,
   Document,
-  FileNoUploadedError,
+  FileNotUploadedError,
   FileBuffer,
   UnsupportedFileExtensionError,
   FileBufferType,

--- a/src/internal/FileBufferType.ts
+++ b/src/internal/FileBufferType.ts
@@ -3,12 +3,7 @@
  * raised when an `ArrayBuffer` with an unsupported file extension is passed to
  * the `FileBufferType` class.
  */
-export class UnsupportedFileExtensionError extends Error {
-  constructor () {
-    super('Unsupported file extension for given buffer. Only .pdf and .epub extensions supported')
-    this.name = 'UnsupportedFileExtensionError'
-  }
-}
+export class UnsupportedFileExtensionError extends Error {}
 
 /**
  * Each `ArrayBuffer` presents a specific signature representing its corresponding
@@ -28,6 +23,18 @@ const MIME_TYPE_MAPS = {
   epub: 'application/epub+zip'
 }
 
+/**
+ * Represents the type of the file associated to its buffer.
+ *
+ * It is possible to identify the type of a file by examining its buffer.
+ * This class encapsulates the logic to infer a files type from its
+ * respective buffer.
+ *
+ * Since the reMarkable Cloud API only allows uploading `.pdf` and `.epub`
+ * files, the class only handles buffers with that extension, raising an
+ * { @link UnsupportedFileExtensionError } when a buffer from an unsupported
+ * file extension is passed.
+ */
 export default class FileBufferType {
   static extension (buffer: ArrayBuffer): 'pdf' | 'epub' {
     const signature = (new Uint8Array(buffer)).slice(0, 4)
@@ -38,7 +45,7 @@ export default class FileBufferType {
       }
     }
 
-    throw new UnsupportedFileExtensionError()
+    throw new UnsupportedFileExtensionError('Unsupported file extension. Only .pdf and .epub files are supported.')
   }
 
   static mimeType (buffer: ArrayBuffer): string {
@@ -46,7 +53,13 @@ export default class FileBufferType {
     return MIME_TYPE_MAPS[type]
   }
 
+  /**
+   * Buffer file extension
+   */
   readonly extension: string
+  /**
+   * MIME type of the buffer file
+   */
   readonly mimeType: string
 
   constructor (buffer: ArrayBuffer) {

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,5 +1,5 @@
 import Document from './Document'
-import FileBuffer, { FileNoUploadedError } from './FileBuffer'
+import FileBuffer, { FileNotUploadedError } from './FileBuffer'
 import FileBufferType, { UnsupportedFileExtensionError } from './FileBufferType'
 import FileSystem from './FileSystem'
 import Folder from './Folder'
@@ -7,7 +7,7 @@ import HashUrl from './HashUrl'
 
 export {
   Document,
-  FileNoUploadedError,
+  FileNotUploadedError,
   FileBuffer,
   UnsupportedFileExtensionError,
   FileBufferType,

--- a/test/fixtures/documents/sample.txt
+++ b/test/fixtures/documents/sample.txt
@@ -1,0 +1,1 @@
+Cacahue

--- a/test/internal/FileBuffer.test.ts
+++ b/test/internal/FileBuffer.test.ts
@@ -1,7 +1,8 @@
-import FileBuffer from '../../src/./internal/FileBuffer'
+import { FileBuffer, UnsupportedFileExtensionError } from '../../src/internal'
 import ServiceManager from '../../src/serviceDiscovery/ServiceManager'
+import { Session } from '../../src/authentication'
+
 import { setupHttpRecording } from '../helpers/pollyHelpers'
-import { Session } from '../../src'
 
 describe('FileBuffer', () => {
   let serviceManager: ServiceManager = null
@@ -9,8 +10,7 @@ describe('FileBuffer', () => {
   setupHttpRecording()
 
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    const session = new Session(global.unitTestParams.sessionToken)
+    const session = new Session(global.unitTestParams.sessionToken as string)
 
     serviceManager = new ServiceManager(session)
   })
@@ -19,17 +19,29 @@ describe('FileBuffer', () => {
     it('given an e-pub file buffer, uploads file', async () => {
       const buffer = await FileBuffer.fromLocalFile('./test/fixtures/documents/sample.epub', serviceManager)
 
+      expect(buffer.uploaded).toBe(false)
+
       await buffer.upload()
 
       expect(buffer.uploaded).toBe(true)
+      expect(buffer.documentReference).toBeDefined()
     }, 10000000)
 
     it('given a pdf file buffer, uploads file', async () => {
       const buffer = await FileBuffer.fromLocalFile('./test/fixtures/documents/sample.pdf', serviceManager)
 
+      expect(buffer.uploaded).toBe(false)
+
       await buffer.upload()
 
       expect(buffer.uploaded).toBe(true)
+      expect(buffer.documentReference).toBeDefined()
     }, 10000000)
+
+    it('given a incompatible file buffer, throws error', async () => {
+      await expect(async () => {
+        await FileBuffer.fromLocalFile('./test/fixtures/documents/sample.txt', serviceManager)
+      }).rejects.toThrow(UnsupportedFileExtensionError)
+    })
   })
 })


### PR DESCRIPTION
- Add documentation.
- Refactor error triggering for FileBuffer & FileBuffer type.
- Add type to represent a DocumentReference. It represents the response returned by the reMarkable API on successful file upload.
- Extend test coverage.