### PR TITLE
chore: release flow bundling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 #
 # This workflow will install a prebuilt Ruby version, install dependencies, and
 # run tests and linters.
-name: "A Remarkable JS SDK"
+name: "Run CI quality checks: tests, linters, ..."
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Package to npmjs
+name: Publish new package version in NPM
 on:
   release:
     types: [published]
@@ -12,9 +12,9 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-          # Defaults to the user or organization that owns the workflow file
           scope: '@octocat'
       - run: yarn
+      - run: yarn build
       - run: yarn npm publish // for Yarn version 1, use `yarn publish` instead
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PDF & ePub file upload to reMarkable Cloud.
 - File Tree navigator.
 
----
-[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.0...HEAD
-[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.1.0
+[unreleased]: https://github.com/Alberto-Writes-Typescript/a-remarkable-js-sdk/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Alberto-Writes-Typescript/a-remarkable-js-sdk/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a-remarkable-js-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "a reMarkable Cloud API wrapper written in TypeScript",
   "keywords": [
     "reMarkable",
@@ -39,7 +39,8 @@
     "build": "yarn build:tsup",
     "lint:eslint": "yarn run eslint src test -c config/.eslintrc --ignore-path config/.eslintignore",
     "lint:tsc": "tsc --noEmit -p ./config",
-    "lint": "yarn run lint:eslint && yarn run lint:tsc"
+    "lint": "yarn run lint:eslint && yarn run lint:tsc",
+    "version:bump": "npx tsx --tsconfig ./config/tsconfig.json ./scripts/bumpPackageVersion.ts"
   },
   "dependencies": {
     "base64-js": "^1.5.1",
@@ -72,6 +73,7 @@
     "open": "^10.1.0",
     "path": "^0.12.7",
     "readline-sync": "^1.4.10",
+    "semver": "^7.6.0",
     "ts-jest": "^29.1.2",
     "tsup": "^8.0.2",
     "typescript": "^5.3.3"

--- a/scripts/bumpPackageVersion.ts
+++ b/scripts/bumpPackageVersion.ts
@@ -1,0 +1,121 @@
+// @ts-expect-error - Expected error
+import path from 'path'
+import * as fs from 'fs'
+import { inc } from 'semver'
+import { spinner, intro, outro, confirm, cancel, select } from '@clack/prompts'
+
+class PackageJsonManager {
+  private readonly path: string
+  private readonly payload: Record<string, unknown>
+
+  constructor () {
+    this.path = path.resolve(process.cwd(), 'package.json')
+    this.payload = JSON.parse(fs.readFileSync(this.path, 'utf-8'))
+  }
+
+  get version (): string {
+    return this.payload.version as string
+  }
+
+  set version (newVersion: string) {
+    this.payload.version = newVersion
+    this.save()
+  }
+
+  private save (): void {
+    fs.writeFileSync(this.path, JSON.stringify(this.payload, null, 2))
+  }
+}
+
+class ChangelogManager {
+  private readonly path: string
+
+  constructor () {
+    this.path = path.resolve(process.cwd(), 'CHANGELOG.md')
+  }
+
+  get content (): string {
+    return fs.readFileSync(this.path, 'utf-8')
+  }
+
+  set content (newContent: string) {
+    fs.writeFileSync(this.path, newContent)
+  }
+
+  bump (newVersion: string): void {
+    try {
+      this.addNewVersionSection(newVersion)
+      this.updateTagComparisonLinks(newVersion)
+    } catch (error) {
+      console.error('Error updating CHANGELOG.md:', error)
+    }
+  }
+
+  private addNewVersionSection (newVersion: string): void {
+    const lines = this.content.split('\n')
+    const unreleasedIndex = lines.findIndex(line => line.includes('## [Unreleased]'))
+
+    const currentDate = new Date().toISOString().split('T')[0]
+    const newVersionLine = `\n## [${newVersion}] - ${currentDate}`
+    lines.splice(unreleasedIndex + 1, 0, newVersionLine)
+
+    this.content = lines.join('\n')
+  }
+
+  private updateTagComparisonLinks (newVersion: string): void {
+    const lines = this.content.split('\n')
+    const unreleasedLinkIndex = lines.findIndex(line => line.startsWith('[unreleased]:'))
+
+    const previousVersionLine = lines.slice(unreleasedLinkIndex + 1)[0]
+    const previousVersion = previousVersionLine.slice(1, previousVersionLine.indexOf(']:'))
+    lines[unreleasedLinkIndex] = `[unreleased]: https://github.com/Alberto-Writes-Typescript/a-remarkable-js-sdk/compare/v${newVersion}...HEAD`
+
+    // Add the new version link
+    const newVersionLink = `[${newVersion}]: https://github.com/Alberto-Writes-Typescript/a-remarkable-js-sdk/compare/v${previousVersion}...v${newVersion}`
+    lines.splice(unreleasedLinkIndex + 1, 0, newVersionLink)
+
+    this.content = lines.join('\n')
+  }
+}
+
+/**
+ * SCRIPT BODY
+ */
+void (async () => {
+  intro('Release a newer package version')
+
+  const packageJsonManager = new PackageJsonManager()
+  const changelogManager = new ChangelogManager()
+
+  const releaseKind = await select({
+    message: 'Which kind of version do you want to release?',
+    options: [
+      { value: 'major', label: 'MAJOR', hint: 'when you make incompatible API changes' },
+      { value: 'minor', label: 'MINOR', hint: 'when you add functionality in a backward compatible manner' },
+      { value: 'patch', label: 'PATCH', hint: 'when you make backward compatible bug fixes' }
+    ]
+  })
+
+  const newVersion = inc(packageJsonManager.version, releaseKind as 'major' | 'minor' | 'patch')
+
+  const bumpConfirmation = await confirm({
+    message: `Bumping package version to ${newVersion}. Do you want to continue?`
+  })
+
+  if (!bumpConfirmation) {
+    cancel('Operation cancelled...')
+    process.exit(0)
+  }
+
+  const s = spinner()
+
+  s.start('Updating package.json')
+  packageJsonManager.version = newVersion
+  s.stop('package.json updated!')
+
+  s.start('Updating CHANGELOG.md')
+  changelogManager.bump(newVersion)
+  s.stop('CHANGELOG.md updated!')
+
+  outro('Test data for unit tests regenerated successfully! Your HTTP records and test environment variables have been updated')
+})()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,11 +3265,6 @@ is-typed-array@^1.1.13:
   dependencies:
     which-typed-array "^1.1.14"
 
-is-unicode-supported@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz#d824984b616c292a2e198207d4a609983842f714"
-  integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
-
 is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
@@ -4769,7 +4764,7 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.0.0, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4:
+semver@^7.0.0, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==


### PR DESCRIPTION
Creates a new task executable under `yarn run version:bump` which updates `package.json` version and `CHANGELOG.md` when releasing new package versions.