### PR TITLE
feat: HTTP client configurable in ServiceManager.

### DIFF
--- a/src/RemarkableClient.ts
+++ b/src/RemarkableClient.ts
@@ -2,6 +2,8 @@ import { Device, Session } from './authentication'
 import { type Folder, type Document } from './internal'
 import FileBuffer, { type DocumentReference } from './internal/FileBuffer'
 import FileSystem from './internal/FileSystem'
+import FetchClient from './net/FetchClient'
+import NodeClient from './net/NodeClient'
 import ServiceManager from './serviceDiscovery/ServiceManager'
 
 /**
@@ -12,15 +14,23 @@ import ServiceManager from './serviceDiscovery/ServiceManager'
  * - Upload documents
  */
 export default class RemarkableClient {
+  static async withFetchHttpClient (deviceToken: string, sessionToken?: string): Promise<RemarkableClient> {
+    return new RemarkableClient(deviceToken, sessionToken, FetchClient)
+  }
+
+  static async withNodeHttpClient (deviceToken: string, sessionToken?: string): Promise<RemarkableClient> {
+    return new RemarkableClient(deviceToken, sessionToken, NodeClient)
+  }
+
   device: Device
   session: Session
   serviceManager: ServiceManager
 
-  constructor (deviceToken: string, sessionToken?: string) {
+  constructor (deviceToken: string, sessionToken?: string, httpClientConstructor: unknown = NodeClient) {
     this.device = new Device(deviceToken)
     if (sessionToken != null) {
       this.session = new Session(sessionToken)
-      this.serviceManager = new ServiceManager(this.session)
+      this.serviceManager = new ServiceManager(this.session, httpClientConstructor)
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   HashUrl
 } from './internal'
 import HttpClient from './net/HttpClient'
+import FetchClient from './net/FetchClient'
 import NodeClient from './net/NodeClient'
 import ServiceManager from './serviceDiscovery/ServiceManager'
 
@@ -23,6 +24,6 @@ export {
   FileSystem,
   Folder,
   HashUrl,
-  HttpClient, NodeClient,
+  HttpClient, NodeClient, FetchClient,
   ServiceManager
 }

--- a/src/serviceDiscovery/ServiceManager.ts
+++ b/src/serviceDiscovery/ServiceManager.ts
@@ -54,12 +54,13 @@ export default class ServiceManager {
   public readonly session: Session
   public readonly httpClient: HttpClient
 
-  constructor (session: Session) {
+  constructor (session: Session, HttpClientConstructor: unknown = NodeClient) {
     this.session = session
-    this.httpClient = new NodeClient(
-      SERVICE_DISCOVERY_HOST,
-      { Authorization: `Bearer ${this.session.token}` }
-    )
+
+    // @ts-expect-error - httpClientConstructor is a constructor
+    this.httpClient = new HttpClientConstructor(SERVICE_DISCOVERY_HOST, {
+      Authorization: `Bearer ${this.session.token}`
+    })
   }
 
   /**


### PR DESCRIPTION
Now `ServiceManager` accepts HTTPClient class references in its constructor, allowing to use different http clients to perform requests agains the reMarkable Cloud API.