### PR TITLE
feat: remarkable client session state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `RemarkableClient` method to verify current session has not expired.
+
 ## [0.2.2] - 2024-04-11
 
 ### Fixed

--- a/src/RemarkableClient.ts
+++ b/src/RemarkableClient.ts
@@ -14,11 +14,11 @@ import ServiceManager from './serviceDiscovery/ServiceManager'
  * - Upload documents
  */
 export default class RemarkableClient {
-  static async withFetchHttpClient (deviceToken: string, sessionToken?: string): Promise<RemarkableClient> {
+  static withFetchHttpClient (deviceToken: string, sessionToken?: string): RemarkableClient {
     return new RemarkableClient(deviceToken, sessionToken, FetchClient)
   }
 
-  static async withNodeHttpClient (deviceToken: string, sessionToken?: string): Promise<RemarkableClient> {
+  static withNodeHttpClient (deviceToken: string, sessionToken?: string): RemarkableClient {
     return new RemarkableClient(deviceToken, sessionToken, NodeClient)
   }
 

--- a/src/RemarkableClient.ts
+++ b/src/RemarkableClient.ts
@@ -22,27 +22,35 @@ export default class RemarkableClient {
     return new RemarkableClient(deviceToken, sessionToken, NodeClient)
   }
 
-  device: Device
-  session: Session
-  serviceManager: ServiceManager
+  readonly #device: Device
+  #serviceManager: ServiceManager
+  #session: Session
 
   constructor (deviceToken: string, sessionToken?: string, httpClientConstructor: unknown = NodeClient) {
-    this.device = new Device(deviceToken)
+    this.#device = new Device(deviceToken)
     if (sessionToken != null) {
-      this.session = new Session(sessionToken)
-      this.serviceManager = new ServiceManager(this.session, httpClientConstructor)
+      this.#session = new Session(sessionToken)
+      this.#serviceManager = new ServiceManager(this.session, httpClientConstructor)
     }
+  }
+
+  get device (): Device {
+    return this.#device
+  }
+
+  get session (): Session {
+    return this.#session
   }
 
   async connect (): Promise<void> {
     if (this.sessionExpired) {
-      this.session = await this.device.connect()
-      this.serviceManager = new ServiceManager(this.session)
+      this.#session = await this.device.connect()
+      this.#serviceManager = new ServiceManager(this.session)
     }
   }
 
   async fileSystem (): Promise<FileSystem> {
-    return await FileSystem.initialize(this.serviceManager)
+    return await FileSystem.initialize(this.#serviceManager)
   }
 
   async document (id: string): Promise<Document | undefined> {
@@ -56,11 +64,11 @@ export default class RemarkableClient {
   }
 
   async upload (name: string, buffer: ArrayBuffer): Promise<DocumentReference> {
-    const fileBuffer = new FileBuffer(name, buffer, this.serviceManager)
+    const fileBuffer = new FileBuffer(name, buffer, this.#serviceManager)
     return await fileBuffer.upload()
   }
 
-  private get sessionExpired (): boolean {
+  get sessionExpired (): boolean {
     return this.session == null || this.session.expired
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Device, type DeviceDescription, Session } from './authentication'
 import {
   Document,
+  DocumentReference,
   FileNotUploadedError,
   FileBuffer,
   UnsupportedFileExtensionError,
@@ -18,6 +19,7 @@ import RemarkableClient from './RemarkableClient'
 export {
   Device, type DeviceDescription, Session,
   Document,
+  DocumentReference,
   FileNotUploadedError,
   FileBuffer,
   UnsupportedFileExtensionError,

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,5 +1,5 @@
 import Document from './Document'
-import FileBuffer, { FileNotUploadedError } from './FileBuffer'
+import FileBuffer, { FileNotUploadedError, DocumentReference } from './FileBuffer'
 import FileBufferType, { UnsupportedFileExtensionError } from './FileBufferType'
 import FileSystem from './FileSystem'
 import Folder from './Folder'
@@ -7,6 +7,7 @@ import HashUrl from './HashUrl'
 
 export {
   Document,
+  DocumentReference,
   FileNotUploadedError,
   FileBuffer,
   UnsupportedFileExtensionError,


### PR DESCRIPTION
Updates the `RemarkableClient` public interface with a method to verify if the current session is valid or expired.