### PR TITLE
fix: `FileBuffer` `buffer` kind.

### DIFF
--- a/src/RemarkableClient.ts
+++ b/src/RemarkableClient.ts
@@ -63,7 +63,7 @@ export default class RemarkableClient {
     return fileSystem.folder(id)
   }
 
-  async upload (name: string, buffer: ArrayBuffer): Promise<DocumentReference> {
+  async upload (name: string, buffer: Buffer): Promise<DocumentReference> {
     const fileBuffer = new FileBuffer(name, buffer, this.#serviceManager)
     return await fileBuffer.upload()
   }

--- a/src/internal/FileBuffer.ts
+++ b/src/internal/FileBuffer.ts
@@ -41,7 +41,7 @@ export class DocumentReference {
  * Represents a file content, encoded as a buffer, ready to be uploaded
  * to reMarkable Cloud.
  *
- * Encapsulates the logic to handle file upload. Given the ArrayBuffer
+ * Encapsulates the logic to handle file upload. Given the Buffer
  * content of a file, it verifies the type compatibility with the
  * reMarkable Cloud API and provides an interface to upload the file
  * and get a reference to its cloud equivalent when successfully
@@ -64,27 +64,27 @@ export default class FileBuffer {
   }
 
   /**
-   * Creates FileBuffer from file ArrayBuffer and uploads it
+   * Creates FileBuffer from file Buffer and uploads it
    *
    * @param name - File name
    * @param buffer - File content
    * @param serviceManager
    */
-  static async upload (name: string, buffer: ArrayBuffer, serviceManager: ServiceManager): Promise<FileBuffer> {
+  static async upload (name: string, buffer: Buffer, serviceManager: ServiceManager): Promise<FileBuffer> {
     const fileBuffer = new FileBuffer(name, buffer, serviceManager)
     await fileBuffer.upload()
     return fileBuffer
   }
 
   public readonly name: string
-  public readonly buffer: ArrayBuffer
+  public readonly buffer: Buffer
   public readonly type: FileBufferType
   public documentReference?: DocumentReference
 
   private httpClient?: HttpClient
   private readonly serviceManager: ServiceManager
 
-  constructor (name: string, buffer: ArrayBuffer, serviceManager: ServiceManager) {
+  constructor (name: string, buffer: Buffer, serviceManager: ServiceManager) {
     this.name = name
     this.buffer = buffer
     this.serviceManager = serviceManager

--- a/src/internal/FileBufferType.ts
+++ b/src/internal/FileBufferType.ts
@@ -1,12 +1,12 @@
 /**
  * The reMarkable API only works with `.pdf` and `.epub` files. This error is
- * raised when an `ArrayBuffer` with an unsupported file extension is passed to
+ * raised when an `Buffer` with an unsupported file extension is passed to
  * the `FileBufferType` class.
  */
 export class UnsupportedFileExtensionError extends Error {}
 
 /**
- * Each `ArrayBuffer` presents a specific signature representing its corresponding
+ * Each `Buffer` presents a specific signature representing its corresponding
  * file type at the beginning. This constants list the signature for each one of
  * the supported file types.
  */
@@ -36,7 +36,7 @@ const MIME_TYPE_MAPS = {
  * file extension is passed.
  */
 export default class FileBufferType {
-  static extension (buffer: ArrayBuffer): 'pdf' | 'epub' {
+  static extension (buffer: Buffer): 'pdf' | 'epub' {
     const signature = (new Uint8Array(buffer)).slice(0, 4)
 
     for (const [type, sig] of Object.entries(BUFFER_TYPE_SIGNATURES)) {
@@ -48,7 +48,7 @@ export default class FileBufferType {
     throw new UnsupportedFileExtensionError('Unsupported file extension. Only .pdf and .epub files are supported.')
   }
 
-  static mimeType (buffer: ArrayBuffer): string {
+  static mimeType (buffer: Buffer): string {
     const type = this.extension(buffer)
     return MIME_TYPE_MAPS[type]
   }
@@ -62,7 +62,7 @@ export default class FileBufferType {
    */
   readonly mimeType: string
 
-  constructor (buffer: ArrayBuffer) {
+  constructor (buffer: Buffer) {
     this.extension = FileBufferType.extension(buffer)
     this.mimeType = FileBufferType.mimeType(buffer)
   }

--- a/test/internal/FileBufferType.test.ts
+++ b/test/internal/FileBufferType.test.ts
@@ -11,7 +11,7 @@ describe('FileBufferType', () => {
   })
 
   it('if unsupported file extension buffer is provided, throws exception', async () => {
-    const unsupportedBuffer = new ArrayBuffer(4)
+    const unsupportedBuffer = Buffer.alloc(4)
 
     expect(() => new FileBufferType(unsupportedBuffer)).toThrow(UnsupportedFileExtensionError)
   })
@@ -32,7 +32,7 @@ describe('FileBufferType', () => {
     })
 
     it('if unsuported file extension buffer is given, throws exception', async () => {
-      const unsupportedBuffer = new ArrayBuffer(4)
+      const unsupportedBuffer = Buffer.alloc(4)
 
       expect(() => FileBufferType.extension(unsupportedBuffer)).toThrow(UnsupportedFileExtensionError)
     })
@@ -54,7 +54,7 @@ describe('FileBufferType', () => {
     })
 
     it('if unsuported file extension buffer is given, throws exception', async () => {
-      const unsupportedBuffer = new ArrayBuffer(4)
+      const unsupportedBuffer = Buffer.alloc(4)
 
       expect(() => FileBufferType.extension(unsupportedBuffer)).toThrow(UnsupportedFileExtensionError)
     })


### PR DESCRIPTION
After testing the library in a project I noticed the logic to upload the `FileBuffer` is working with `Buffer` instances and not `ArrayBuffer` instances.

This commit changes the interface definition so the `FileBuffer` now handles `Buffer` buffers.