### PR TITLE
feat: pair interface in remarkable client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `RemarkableClient` method to pair new `Device`.
+- `Device` `HttpClient` can be configured (before it was using `NodeClient` only).
+
 ## [0.3.0] - 2024-04-15
 
 ### Added

--- a/src/authentication/Device.ts
+++ b/src/authentication/Device.ts
@@ -3,6 +3,7 @@ import { type DeviceDescription } from './DeviceDescription'
 import ServiceManager from '../serviceDiscovery/ServiceManager'
 import RemarkableTokenPayload from './RemarkableTokenPayload'
 import Session from './Session'
+import NodeClient from '../net/NodeClient'
 
 /**
  * Represents a reMarkable device. Provides an interface to
@@ -29,8 +30,13 @@ export default class Device {
    * @param description - Label which indicates the `device` running environment (web browser, mobile app, ...)
    * @param oneTimeCode - One-time password to authenticate reMarkable Cloud user account when pairing `device`
    */
-  public static async pair (id: string, description: DeviceDescription, oneTimeCode: string): Promise<Device> {
-    const httpClient = ServiceManager.productionHttpClient()
+  public static async pair (
+    id: string,
+    description: DeviceDescription,
+    oneTimeCode: string,
+    HttpClientConstructor: unknown = NodeClient
+  ): Promise<Device> {
+    const httpClient = ServiceManager.productionHttpClient({}, HttpClientConstructor)
 
     const pairResponse = await httpClient.post(
       '/token/json/2/device/new',

--- a/src/authentication/Device.ts
+++ b/src/authentication/Device.ts
@@ -69,14 +69,17 @@ export default class Device {
 
   private readonly httpClient: HttpClient
 
-  constructor (deviceToken: string) {
+  constructor (deviceToken: string, HttpClientConstructor: unknown = NodeClient) {
     const deviceTokenPayload = new RemarkableTokenPayload(deviceToken)
 
     this.id = deviceTokenPayload.deviceId
     this.description = deviceTokenPayload.deviceDescription
     this.token = deviceToken
 
-    this.httpClient = ServiceManager.productionHttpClient({ Authorization: `Bearer ${this.token}` })
+    this.httpClient = ServiceManager.productionHttpClient(
+      { Authorization: `Bearer ${this.token}` },
+      HttpClientConstructor
+    )
   }
 
   /**

--- a/src/serviceDiscovery/ServiceManager.ts
+++ b/src/serviceDiscovery/ServiceManager.ts
@@ -47,8 +47,12 @@ export default class ServiceManager {
    * of this endpoint without requiring a `Device` instance (as it
    * is required for other endpoints).
    */
-  static productionHttpClient (headers: HeadersPayload = {}): HttpClient {
-    return new NodeClient('https://webapp-prod.cloud.remarkable.engineering', headers)
+  static productionHttpClient (
+    headers: HeadersPayload = {},
+    HttpClientConstructor: unknown = NodeClient
+  ): HttpClient {
+    // @ts-expect-error - httpClientConstructor is a constructor
+    return new HttpClientConstructor('https://webapp-prod.cloud.remarkable.engineering', headers)
   }
 
   public readonly session: Session


### PR DESCRIPTION
Add `pair` to the `RemarkableClient` interface & updates `Device` interface to accept custom `HttpClient`s.