### PR TITLE
feat: Add TextEncoder polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "base64-js": "^1.5.1",
+    "fast-text-encoding": "^1.0.6",
     "jwt-decode": "^4.0.0",
     "uuid": "^9.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "base64-js": "^1.5.1",
-    "fast-text-encoding": "^1.0.6",
+    "fastestsmallesttextencoderdecoder": "^1.0.22",
     "jwt-decode": "^4.0.0",
     "uuid": "^9.0.1"
   },

--- a/src/internal/FileBuffer.ts
+++ b/src/internal/FileBuffer.ts
@@ -129,6 +129,6 @@ export default class FileBuffer {
     const encoder = new TextEncoder()
     const namePayload = JSON.stringify({ file_name: this.name })
     const encodedNamePayload = encoder.encode(namePayload)
-    return fromByteArray(encodedNamePayload)
+    return fromByteArray(encodedNamePayload as Uint8Array)
   }
 }

--- a/src/internal/FileBuffer.ts
+++ b/src/internal/FileBuffer.ts
@@ -1,4 +1,4 @@
-import { TextEncoder } from 'util'
+import { TextEncoder } from 'fast-text-encoding'
 import { promises as fs } from 'fs'
 import { fromByteArray } from 'base64-js'
 

--- a/src/internal/FileBuffer.ts
+++ b/src/internal/FileBuffer.ts
@@ -1,4 +1,4 @@
-import { TextEncoder } from 'fast-text-encoding'
+import { TextEncoder } from 'fastestsmallesttextencoderdecoder'
 import { promises as fs } from 'fs'
 import { fromByteArray } from 'base64-js'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,10 +2598,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-text-encoding@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
-  integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
+fastestsmallesttextencoderdecoder@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz#59b47e7b965f45258629cc6c127bf783281c5e93"
+  integrity sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==
 
 fastq@^1.6.0:
   version "1.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,6 +2598,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-text-encoding@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
+  integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
+
 fastq@^1.6.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"


### PR DESCRIPTION
The native `TextEncoder` is not compatible in web browser execution environment. This polyfill makes the encoder available in all environments.